### PR TITLE
feature: remove pdf direct download

### DIFF
--- a/pages/api/inpi-pdf-proxy/[slug].ts
+++ b/pages/api/inpi-pdf-proxy/[slug].ts
@@ -1,9 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { HttpNotFound } from '../../../clients/exceptions';
-import APIRncsProxyClient from '../../../clients/rncs/rncs-proxy-client';
 import routes from '../../../clients/routes';
 import { isSiren } from '../../../utils/helpers/siren-and-siret';
-import logErrorInSentry from '../../../utils/sentry';
+import { logWarningInSentry } from '../../../utils/sentry';
 
 /**
  * Download a pdf directly without storing it locally
@@ -16,30 +15,8 @@ const downloadPdf = async (req: NextApiRequest, res: NextApiResponse) => {
     throw new HttpNotFound(`${siren} is not a valid siren`);
   }
 
-  try {
-    const data = await APIRncsProxyClient({
-      url: routes.rncs.proxy.document.justificatif.directDownload + siren,
-      timeout: 30000,
-    });
-
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename=justificatif_immatriculation_rcs_${siren}.pdf`
-    );
-    res.status(200).send(data);
-  } catch (e: any) {
-    logErrorInSentry('Error in INPI’s PDF Direct Download', {
-      siren,
-      details: e.toString(),
-    });
-
-    res.writeHead(302, {
-      Location: '/erreur/administration/inpi',
-    });
-
-    res.end();
-  }
+  res.redirect(routes.rncs.portail.entreprise + siren + '.pdf');
+  logWarningInSentry('Direct pdf download - redirected', { siren });
 };
 
 export default downloadPdf;


### PR DESCRIPTION
Remove direct download as it : 

- often fails
- when fails it uses a thread for up to 30 seconds, therefore it threatens the application stability

It is replaced with a default redirection to INPI pdf, with no auth