### PR TITLE
feat(share-link): adding share by mail link and fix seo lighthouse re…

### DIFF
--- a/components-ui/icon/index.tsx
+++ b/components-ui/icon/index.tsx
@@ -362,3 +362,20 @@ export const print = (
     <rect x="6" y="14" width="12" height="8"></rect>
   </svg>
 );
+
+export const mail = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+    <polyline points="22,6 12,13 2,6"></polyline>
+  </svg>
+);

--- a/components-ui/social-media/index.tsx
+++ b/components-ui/social-media/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { facebook, linkedin, qrCode, twitter, print } from '../icon';
+import { facebook, linkedin, qrCode, twitter, print, mail } from '../icon';
 import InformationTooltip from '../information-tooltip';
 import { PrintNever } from '../print-visibility';
 
@@ -56,6 +56,20 @@ const SocialMedia: React.FC<{ siren: string }> = ({ siren }) => (
       </span>
       <span>
         <InformationTooltip
+          orientation="right"
+          label="Partager la page de cette entité par Email"
+        >
+          <a
+            href={`mailto:?body=Je voudrais partager la page de cette entité avec vous https://annuaire-entreprises.data.gouv.fr/entreprise/${siren}`}
+            title="Partager cette page par Email"
+            className="no-style-link"
+          >
+            {mail}
+          </a>
+        </InformationTooltip>
+      </span>
+      <span>
+        <InformationTooltip
           label="Imprimer cette page ou la sauvegarder au format PDF"
           orientation="right"
         >
@@ -98,6 +112,7 @@ const SocialMedia: React.FC<{ siren: string }> = ({ siren }) => (
       .social-media span a,
       .social-media span div {
         cursor: pointer !important;
+        padding: 8px;
       }
       .social-media span a:after {
         display: none;


### PR DESCRIPTION
Change size of share link button to fit with the lighthouse SEO requirement
<img width="956" alt="Screenshot 2022-12-01 at 15 24 28" src="https://user-images.githubusercontent.com/119595487/205081940-c3e0afbd-8a5d-4194-a49f-d338213110fb.png">




Adding button to share by email
<img width="306" alt="Screenshot 2022-12-01 at 15 45 06" src="https://user-images.githubusercontent.com/119595487/205082392-d0c10451-4130-45d2-b6a5-a1d2e090b68e.png">


@XavierJp  We should define which message add to subject and body properties.

Actual wording :
Subject : ""
Body : "Je voudrais partager la page de cette entité avec vous https://annuaire-entreprises.data.gouv.fr/entreprise/245701206"