### PR TITLE
chore: delete advanced search js

### DIFF
--- a/components/search-filters/filter-geo.tsx
+++ b/components/search-filters/filter-geo.tsx
@@ -15,7 +15,7 @@ export const FilterGeo: React.FC<{ cp_dep?: string; cp_dep_label?: string }> =
     const [isLoading, setLoading] = useState(false);
     const [geoSuggests, setGeoSuggests] = useState([]);
 
-    const geoSearchRef = useRef(null);
+    const geoSearchRef = useRef<HTMLInputElement | null>(null);
 
     const search = debounce(async (inputElement: any) => {
       const term = inputElement.target.value;

--- a/components/search-filters/filter-geo.tsx
+++ b/components/search-filters/filter-geo.tsx
@@ -34,8 +34,9 @@ export const FilterGeo: React.FC<{ cp_dep?: string; cp_dep_label?: string }> =
       setDep(value);
       setLabelDep(label);
       setGeoSuggests([]);
-      //@ts-ignore
-      geoSearchRef.current.value = label;
+      if (geoSearchRef.current) {
+        geoSearchRef.current.value = label;
+      }
     };
 
     return (

--- a/components/search-filters/filter-geo.tsx
+++ b/components/search-filters/filter-geo.tsx
@@ -1,0 +1,90 @@
+import axios from 'axios';
+import { useRef, useState } from 'react';
+import { Loader } from '#components-ui/loader';
+import { debounce } from '#utils/helpers/debounce';
+
+interface IGeoSuggest {
+  label: string;
+  value: string;
+}
+
+export const FilterGeo: React.FC<{ cp_dep?: string; cp_dep_label?: string }> =
+  ({ cp_dep, cp_dep_label }) => {
+    const [labelDep, setLabelDep] = useState(cp_dep_label);
+    const [dep, setDep] = useState(cp_dep);
+    const [isLoading, setLoading] = useState(false);
+    const [geoSuggests, setGeoSuggests] = useState([]);
+
+    const geoSearchRef = useRef(null);
+
+    const search = debounce(async (inputElement: any) => {
+      const term = inputElement.target.value;
+      if (!term) {
+        setGeoSuggests([]);
+        return;
+      }
+      setLoading(true);
+      axios.get(`/api/geo/${term}`).then((response) => {
+        setGeoSuggests(response.data);
+        setLoading(false);
+      });
+    });
+
+    const selectDep = ({ label, value }: IGeoSuggest) => {
+      setDep(value);
+      setLabelDep(label);
+      setGeoSuggests([]);
+      //@ts-ignore
+      geoSearchRef.current.value = label;
+    };
+
+    return (
+      <>
+        <input
+          ref={geoSearchRef}
+          className="fr-input"
+          onChange={search}
+          name="cp_dep_label"
+          defaultValue={labelDep}
+          placeholder="ex : Rennes"
+          autoComplete="off"
+          type="search"
+        />
+        <input
+          name="cp_dep"
+          value={dep}
+          style={{ display: 'none' }}
+          onChange={() => {}}
+        />
+        <div className="drop-down">
+          {isLoading ? (
+            <div className="layout-center">
+              <Loader />
+            </div>
+          ) : (
+            geoSuggests.map((suggest: IGeoSuggest) => (
+              <div
+                className="suggest cursor-pointer"
+                onClick={() => selectDep(suggest)}
+              >
+                {suggest.label}
+              </div>
+            ))
+          )}
+        </div>
+        <style jsx>{`
+          div.drop-down {
+            overflow: auto;
+            max-height: 250px;
+            margin-top: 10px;
+          }
+          div.suggest {
+            padding: 8px 4px;
+          }
+          div.suggest:hover {
+            background: #eee;
+          }
+        `}</style>
+      </>
+    );
+  };

--- a/components/search-filters/filter.tsx
+++ b/components/search-filters/filter.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactElement, useState } from 'react';
+import { ReactElement, useState } from 'react';
 import ButtonLink from '#components-ui/button';
 import {
   buildSearchQuery,
@@ -143,6 +143,7 @@ const Filter = ({
             max-height: 350px;
             overflow-y: auto;
             z-index: 100;
+            padding: 0 4px;
           }
 
           @media only screen and (min-width: 1px) and (max-width: 991px) {

--- a/components/search-filters/index.tsx
+++ b/components/search-filters/index.tsx
@@ -1,12 +1,11 @@
-import axios from 'axios';
-import React, { useState } from 'react';
-import AsyncSelect from 'react-select/async';
+import React from 'react';
 import { SimpleSeparator } from '#components-ui/horizontal-separator';
 import Select from '#components-ui/select';
 import SelectCodeNaf from '#components-ui/select/select-code-naf';
 import SelectCodeSectionNaf from '#components-ui/select/select-section-naf';
 import { extractFilters, IParams } from '#models/search-filter-params';
 import Filter from './filter';
+import { FilterGeo } from './filter-geo';
 
 const SearchFilters: React.FC<{
   searchParams?: IParams;
@@ -26,15 +25,6 @@ const SearchFilters: React.FC<{
     dmax,
   } = searchParams || {};
 
-  const [labelDep, setLabelDep] = useState(cp_dep_label);
-
-  const loadOptions = async (
-    inputText: string
-  ): Promise<[{ label: string; value: string }]> =>
-    inputText
-      ? axios.get(`/api/geo/${inputText}`).then((response) => response.data)
-      : [];
-
   const { localisationFilter, dirigeantFilter, administrativeFilter } =
     extractFilters(searchParams || {});
 
@@ -48,51 +38,7 @@ const SearchFilters: React.FC<{
         addSaveClearButton
       >
         <label>Code postal ou numéro de département :</label>
-        <AsyncSelect
-          cacheOptions
-          defaultOptions
-          name="cp_dep"
-          noOptionsMessage={() =>
-            'Saisissez une ville ou un département pour rechercher son code.'
-          }
-          menuPosition="fixed"
-          placeholder="ex: 35000"
-          id="long-value-select"
-          instanceId="long-value-select"
-          defaultValue={{ value: cp_dep || '', label: cp_dep_label || '' }}
-          onChange={(data) => {
-            if (data?.label) {
-              setLabelDep(data.label);
-            }
-          }}
-          loadOptions={loadOptions}
-          styles={{
-            menuPortal: (base) => ({ ...base, zIndex: 10 }),
-            dropdownIndicator: (base) => ({
-              ...base,
-              color: 'black',
-              '&:hover': {
-                color: 'black',
-              },
-            }),
-            control: (baseStyles) => ({
-              ...baseStyles,
-              backgroundColor: '#eeeeee',
-              border: 'none',
-              borderRadius: '0.25rem 0.25rem 0 0',
-              borderBottom: '2px solid black',
-              '&:hover': {
-                borderBottom: '2px solid black',
-              },
-            }),
-          }}
-        />
-        <input
-          style={{ display: 'none' }}
-          name="cp_dep_label"
-          onChange={() => undefined}
-          value={labelDep}
-        />
+        <FilterGeo cp_dep={cp_dep} cp_dep_label={cp_dep_label} />
       </Filter>
       <Filter
         label="Dirigeant"

--- a/utils/helpers/debounce.ts
+++ b/utils/helpers/debounce.ts
@@ -1,0 +1,7 @@
+export const debounce = (fn: Function, ms = 300) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  };
+};


### PR DESCRIPTION
Alternative to `react-select` of geo filter. Only apply to Geo filters. React-select seems perfect for NAF/APE selection

Pros :
- easier to fix / tweak
- comply with dsfr and Jeremie's mock up

Cons
- not a lib
- specific to geo search

