### PR TITLE
ops: change default issue assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Signaler un bug
 about: Je viens de rencontrer un problème.
 title: '[BUG]'
 labels: bug
-assignees: HAEKADI
+assignees: XavierJp
 ---
 
 ## Sujet du problème


### PR DESCRIPTION
- Changement mineur.
- Zones impactées : ISSUE TEMPLATE GITHUB.
- Détails :
  - Vous n'avez pas changé l'assignee par défaut sur l'issue template utilisé pour l'api de recherche. Les nouvelles issues me sont donc automatiquement assignées.

