### PR TITLE
ops: change default issue assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposer-une-amélioration---.md
+++ b/.github/ISSUE_TEMPLATE/proposer-une-amélioration---.md
@@ -3,7 +3,7 @@ name: "Proposer une amélioration \t "
 about: Créer un ticket pour nous suggérer une fonctionnalité.
 title: '[FEATURE]'
 labels: enhancement
-assignees: HAEKADI
+assignees: XavierJp
 ---
 
 ## Votre demande de feature est-elle liée à un problème ?


### PR DESCRIPTION
Changement mineur.
Zones impactées : PROPOSER UNE AMELIORATION TEMPLATE GITHUB.
Détails :
Vous n'avez pas changer l'assignee par défaut sur la template `proposer une amélioration`. Les nouvelles issues me sont donc automatiquement assignées.
