### PR TITLE
feat: use 500 in route api/ping/XXX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,5 @@
   ],
   "eslint.enable": true,
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+  "editor.codeActionsOnSave": ["source.organizeImports", "source.fixAll"]
 }

--- a/pages/api/ping/[slug].ts
+++ b/pages/api/ping/[slug].ts
@@ -11,7 +11,7 @@ const ping = async (
     if (test) {
       res.status(200).json({ message: 'ok' });
     } else {
-      res.status(status).json({ message: 'ko' });
+      res.status(500).json({ message: 'ko', status });
     }
   } catch (e: any) {
     if (e instanceof APISlugNotFound) {


### PR DESCRIPTION
Merci de contribuer à Annuaire des Entreprises ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

- Changement mineur.
- Zones impactées : `pages/api/ping/[slug].ts`.
- Détails : 
  > [feat: use 500 in route api/ping/XXX](https://github.com/etalab/annuaire-entreprises-site/commit/0d073fa2582a04d9879c546b4faca0a96bc78be1)
4XX and 5XX errors are directly interpreted semantically by Baleen
and Uptime Robot resulting in new bugs.
fix https://github.com/etalab/annuaire-entreprises-site/issues/631