### PR TITLE
feat: reload api monitoring page every minute to refresh monitors

### DIFF
--- a/pages/donnees/api.tsx
+++ b/pages/donnees/api.tsx
@@ -28,6 +28,16 @@ const StatusPage: NextPageWithLayout<IProps> = ({
       title="Statut des API utilisées par l'Annuaire des Entreprises"
       noIndex
     />
+    <div
+      dangerouslySetInnerHTML={{
+        __html: `
+          <script>
+            // reload page every minute
+            window.setTimeout(function() {window.location.reload()}, 60*1000)
+          </script>
+  `,
+      }}
+    />
     <div className="content-container">
       <h1>Statut des API utilisées</h1>
       <p>


### PR DESCRIPTION
Add an auto refresh as montoring gets updated every minute, but you currently need to reload manually to get an update on monitorings.

https://annuaire-entreprises.data.gouv.fr/donnees/api

 closes #708 