### PR TITLE
feat: remove anti bot from GEO

### DIFF
--- a/pages/api/data-fetching/geo/[slug].ts
+++ b/pages/api/data-fetching/geo/[slug].ts
@@ -7,7 +7,6 @@ import {
 import { clientRegionsByName } from '#clients/geo/regions';
 import logErrorInSentry from '#utils/sentry';
 import { withAPM } from '#utils/sentry/tracing';
-import withAntiBot from '#utils/session/with-anti-bot';
 
 const geo = async (
   { query: { slug = '' } }: NextApiRequest,
@@ -55,4 +54,4 @@ const geo = async (
   }
 };
 
-export default withAPM(withAntiBot(geo));
+export default withAPM(geo);


### PR DESCRIPTION
antiBot seems unnecessary here : 
- API Geo access is not limited (token or rate limit) -> no need to protect it
- `/rechercher` page can stay open for a long time and filter is manually triggered thus antiBot logic is defeated