### PR TITLE
refactor: move BrowserIsOutdatedBanner from layout

### DIFF
--- a/components/banner/browser-is-outdated.tsx
+++ b/components/banner/browser-is-outdated.tsx
@@ -10,20 +10,26 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
       aria-label="Votre navigateur est obsolète"
     >
       <div className="fr-container">
-        <b>⚠️ Votre navigateur est obsolète : </b>
-        le site est utilisable mais certaines fonctionnalités comme le
-        déclenchement automatique des téléchargements, la recherche avancée ou
-        le copier/coller ne fonctionneront pas.
-        <br />
-        Avoir un navigateur à jour est{' '}
-        <a
-          target="_blank"
-          rel="noreferrer noopener"
-          href="https://www.ssi.gouv.fr/entreprise/precautions-elementaires/bonnes-pratiques-de-navigation-sur-linternet/"
-        >
-          recommandé par l’ANSSI pour naviguer sur internet en sécurité
-        </a>
-        .
+        <h1>⚠️ Votre navigateur est obsolète </h1>
+        <p>
+          La plupart des fonctionalités de ce site ne fonctionneront pas. Vous
+          pourrez uniquement :
+        </p>
+        <ul>
+          <li>Rechercher une entreprise par son nom ou son SIREN</li>
+          <li>Consulter la fiche résumé de l’entreprise</li>
+        </ul>
+        <p>
+          Avoir un navigateur à jour est{' '}
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
+            href="https://www.ssi.gouv.fr/entreprise/precautions-elementaires/bonnes-pratiques-de-navigation-sur-linternet/"
+          >
+            fortement recommandé par l’ANSSI
+          </a>{' '}
+          pour naviguer sur internet en sécurité.
+        </p>
       </div>
     </div>
     <style jsx>{`
@@ -36,6 +42,9 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
         color: #000;
         font-family: 'Marianne', sans-serif;
         border-bottom: 2px solid ${constants.colors.frBlue};
+      }
+      h1 {
+        margin-top: 0;
       }
     `}</style>
   </PrintNever>

--- a/components/banner/browser-is-outdated.tsx
+++ b/components/banner/browser-is-outdated.tsx
@@ -39,11 +39,15 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
       //  https://stackoverflow.com/questions/44891421/detect-es6-import-compatibility
       dangerouslySetInnerHTML={{
         __html: `
-          var esModuleDisabled = typeof window !== 'undefined' 
-            && !('noModule' in HTMLScriptElement.prototype)
+          try {
+             var esModuleDisabled = typeof window !== 'undefined' 
+               && !('noModule' in HTMLScriptElement.prototype);
             
-          if (esModuleDisabled) {
-            getElementById('browser-is-outdated').style.display = 'block'
+             if (esModuleDisabled) {
+                 throw new Error('browser is outdated');
+             }
+          } catch {
+             getElementById('browser-is-outdated').style.display = 'block';
           }
         `,
       }}

--- a/components/banner/browser-is-outdated.tsx
+++ b/components/banner/browser-is-outdated.tsx
@@ -12,8 +12,8 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
       <div className="fr-container">
         <h1>⚠️ Votre navigateur est obsolète </h1>
         <p>
-          La plupart des fonctionalités de ce site ne fonctionneront pas. Vous
-          pourrez uniquement :
+          La plupart des fonctionalités de ce site <b>ne fonctionneront pas</b>.
+          Vous pourrez essentiellement :
         </p>
         <ul>
           <li>Rechercher une entreprise par son nom ou son SIREN</li>
@@ -38,12 +38,13 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
         padding-bottom: 15px;
         font-size: 0.9rem;
         width: 100%;
-        background-color: #ffd0d0;
-        color: #000;
+        background-color: #b50800;
+        color: #fff;
         font-family: 'Marianne', sans-serif;
         border-bottom: 2px solid ${constants.colors.frBlue};
       }
       h1 {
+        color: #fff;
         margin-top: 0;
       }
     `}</style>

--- a/components/banner/browser-is-outdated.tsx
+++ b/components/banner/browser-is-outdated.tsx
@@ -5,7 +5,7 @@ import constants from '#models/constants';
 export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
   <PrintNever>
     <div
-      className="browser-is-outdated"
+      id="browser-is-outdated"
       role="dialog"
       aria-label="Votre navigateur est obsolète"
     >
@@ -32,12 +32,29 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
         </p>
       </div>
     </div>
+
+    <script
+      //   Script that shows warning for browser without ESModule
+      //  https://caniuse.com/?search=esmodule
+      //  https://stackoverflow.com/questions/44891421/detect-es6-import-compatibility
+      dangerouslySetInnerHTML={{
+        __html: `
+          var esModuleDisabled = typeof window !== 'undefined' 
+            && !('noModule' in HTMLScriptElement.prototype)
+            
+          if (esModuleDisabled) {
+            getElementById('browser-is-outdated').style.display = 'block'
+          }
+        `,
+      }}
+    ></script>
     <style jsx>{`
-      .browser-is-outdated {
+      #browser-is-outdated {
         padding-top: 15px;
         padding-bottom: 15px;
         font-size: 0.9rem;
         width: 100%;
+        display: none;
         background-color: #b50800;
         color: #fff;
         font-family: 'Marianne', sans-serif;

--- a/components/layouts/layout-default.tsx
+++ b/components/layouts/layout-default.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren } from 'react';
 import { Question } from '#components-ui/question';
-import { BrowserIsOutdatedBanner } from '#components/banner/browser-is-outdated';
 import { NPSBanner } from '#components/banner/nps';
 import Footer from '#components/footer';
 import { Header } from '#components/header';
@@ -9,20 +8,17 @@ import SocialNetworks from '#components/social-network';
 import { ISession } from '#utils/session';
 
 type IProps = {
-  isBrowserOutdated: boolean;
   searchBar?: boolean;
   session?: ISession | null;
 };
 
 export const LayoutDefault = ({
   children,
-  isBrowserOutdated,
   searchBar = true,
   session = null,
 }: PropsWithChildren<IProps>) => {
   return (
     <div id="page-layout">
-      {isBrowserOutdated && <BrowserIsOutdatedBanner />}
       <WeNeedYouModal />
       <NPSBanner />
 

--- a/components/layouts/layout-search.tsx
+++ b/components/layouts/layout-search.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import { PropsWithChildren } from 'react';
 import { Question } from '#components-ui/question';
-import { BrowserIsOutdatedBanner } from '#components/banner/browser-is-outdated';
 import { NPSBanner } from '#components/banner/nps';
 import Footer from '#components/footer';
 import { Header } from '#components/header';
@@ -12,7 +11,6 @@ import { ISession } from '#utils/session';
 
 type IProps = {
   currentSearchTerm?: string;
-  isBrowserOutdated: boolean;
   map?: boolean;
   searchFilterParams?: IParams;
   session?: ISession | null;
@@ -24,7 +22,6 @@ type IProps = {
  */
 export const LayoutSearch = ({
   children,
-  isBrowserOutdated,
   map,
   session = null,
 }: PropsWithChildren<IProps>) => {
@@ -33,7 +30,6 @@ export const LayoutSearch = ({
 
   return (
     <div id="page-layout">
-      {isBrowserOutdated && <BrowserIsOutdatedBanner />}
       <WeNeedYouModal />
       <NPSBanner />
 

--- a/components/layouts/layout-simple.tsx
+++ b/components/layouts/layout-simple.tsx
@@ -1,17 +1,14 @@
 import React, { PropsWithChildren } from 'react';
-import { BrowserIsOutdatedBanner } from '#components/banner/browser-is-outdated';
 import Footer from '#components/footer';
 import { Header } from '#components/header';
 import { ISession } from '#utils/session';
 
 export const LayoutSimple: React.FC<
   PropsWithChildren<{
-    isBrowserOutdated: boolean;
     session: ISession | null | undefined;
   }>
-> = ({ children, isBrowserOutdated, session }) => (
+> = ({ children, session }) => (
   <div id="page-layout">
-    {isBrowserOutdated && <BrowserIsOutdatedBanner />}
     <Header
       useSearchBar={false}
       useLogo={true}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@types/qrcode": "^1.5.2",
         "@types/react": "^18.2.28",
         "@types/react-dom": "^18.2.13",
-        "@types/ua-parser-js": "^0.7.37",
         "@vcarl/remark-headings": "^0.1.0",
         "autoprefixer": "^10.4.16",
         "axios": "^1.5.1",
@@ -51,7 +50,6 @@
         "remark-rehype": "^11.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2",
-        "ua-parser-js": "^1.0.36",
         "unified": "^11.0.3",
         "vite": "^4.4.11"
       },
@@ -3169,11 +3167,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "node_modules/@types/ua-parser-js": {
-      "version": "0.7.37",
-      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.37.tgz",
-      "integrity": "sha512-4sOxS3ZWXC0uHJLYcWAaLMxTvjRX3hT96eF4YWUh1ovTaenvibaZOE5uXtIp4mksKMLRwo7YDiCBCw6vBiUPVg=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.7",
@@ -14529,28 +14522,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.36.tgz",
-      "integrity": "sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/un-eval": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/qrcode": "^1.5.2",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
-    "@types/ua-parser-js": "^0.7.37",
     "@vcarl/remark-headings": "^0.1.0",
     "autoprefixer": "^10.4.16",
     "axios": "^1.5.1",
@@ -72,7 +71,6 @@
     "remark-rehype": "^11.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
-    "ua-parser-js": "^1.0.36",
     "unified": "^11.0.3",
     "vite": "^4.4.11"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,6 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  const isBrowserOutdated = pageProps?.metadata?.isBrowserOutdated || false;
   const session = pageProps?.metadata?.session || null;
   // Use the layout defined at the page level, otherwise fallback on layout with default settings.
   const getLayout =
@@ -25,7 +24,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const layout = getLayout(<Component {...pageProps} />, session);
   return (
     <>
-      {isBrowserOutdated && <BrowserIsOutdatedBanner />}
+      <BrowserIsOutdatedBanner />
       {layout}
     </>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,13 @@
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import type { ReactElement, ReactNode } from 'react';
-import { ISession } from '#utils/session';
+import { BrowserIsOutdatedBanner } from '#components/banner/browser-is-outdated';
 import { LayoutDefault } from '#components/layouts/layout-default';
+import { ISession } from '#utils/session';
 import '../frontend/src/entry-with-react';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (
-    page: ReactElement,
-    isBrowserOutdated: boolean,
-    session?: ISession | null
-  ) => ReactNode;
+  getLayout?: (page: ReactElement, session?: ISession | null) => ReactNode;
 };
 
 type AppPropsWithLayout = AppProps & {
@@ -23,11 +20,13 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   // Use the layout defined at the page level, otherwise fallback on layout with default settings.
   const getLayout =
     Component.getLayout ??
-    ((page) => (
-      <LayoutDefault isBrowserOutdated={isBrowserOutdated} session={session}>
-        {page}
-      </LayoutDefault>
-    ));
+    ((page) => <LayoutDefault session={session}>{page}</LayoutDefault>);
   //eslint-disable-next-line react/jsx-props-no-spreading
-  return getLayout(<Component {...pageProps} />, isBrowserOutdated, session);
+  const layout = getLayout(<Component {...pageProps} />, session);
+  return (
+    <>
+      {isBrowserOutdated && <BrowserIsOutdatedBanner />}
+      {layout}
+    </>
+  );
 }

--- a/pages/faq/parcours.tsx
+++ b/pages/faq/parcours.tsx
@@ -319,16 +319,8 @@ const Parcours: NextPageWithLayout<{
   );
 };
 
-Parcours.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated,
-  session
-) {
-  return (
-    <LayoutSimple isBrowserOutdated={isBrowserOutdated} session={session}>
-      {page}
-    </LayoutSimple>
-  );
+Parcours.getLayout = function getLayout(page: ReactElement, session) {
+  return <LayoutSimple session={session}>{page}</LayoutSimple>;
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {

--- a/pages/formulaire/merci.tsx
+++ b/pages/formulaire/merci.tsx
@@ -19,15 +19,8 @@ const ThanksPage: NextPageWithLayout = () => {
   );
 };
 
-ThanksPage.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated
-) {
-  return (
-    <LayoutDefault isBrowserOutdated={isBrowserOutdated} searchBar={false}>
-      {page}
-    </LayoutDefault>
-  );
+ThanksPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutDefault searchBar={false}>{page}</LayoutDefault>;
 };
 
 export default ThanksPage;

--- a/pages/formulaire/nps.tsx
+++ b/pages/formulaire/nps.tsx
@@ -175,15 +175,8 @@ const FeedBackPage: NextPageWithLayout = () => {
   );
 };
 
-FeedBackPage.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated
-) {
-  return (
-    <LayoutDefault isBrowserOutdated={isBrowserOutdated} searchBar={false}>
-      {page}
-    </LayoutDefault>
-  );
+FeedBackPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutDefault searchBar={false}>{page}</LayoutDefault>;
 };
 
 export default FeedBackPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { HomeH1 } from '#components-ui/logo/home-h1';
 import { LayoutDefault } from '#components/layouts/layout-default';
 import Meta from '#components/meta';
@@ -72,19 +72,13 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-Index.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated,
-  session
-) {
+Index.getLayout = function getLayout(page: ReactElement, session) {
   return (
-    <LayoutDefault
-      isBrowserOutdated={isBrowserOutdated}
-      searchBar={false}
-      session={session}
-    >
-      {page}
-    </LayoutDefault>
+    <>
+      <LayoutDefault searchBar={false} session={session}>
+        {page}
+      </LayoutDefault>
+    </>
   );
 };
 

--- a/pages/lp/[slug].tsx
+++ b/pages/lp/[slug].tsx
@@ -151,15 +151,8 @@ const LandingPage: NextPageWithLayout<IProps> = ({
   </>
 );
 
-LandingPage.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated: boolean
-) {
-  return (
-    <LayoutDefault isBrowserOutdated={isBrowserOutdated} searchBar={false}>
-      {page}
-    </LayoutDefault>
-  );
+LandingPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutDefault searchBar={false}>{page}</LayoutDefault>;
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/pages/rechercher/carte.tsx
+++ b/pages/rechercher/carte.tsx
@@ -1,11 +1,11 @@
 import { GetServerSideProps } from 'next';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import HiddenH1 from '#components/a11y-components/hidden-h1';
 import { LayoutSearch } from '#components/layouts/layout-search';
 import Meta from '#components/meta';
 import SearchResults from '#components/search-results';
 import StructuredDataSearchAction from '#components/structured-data/search';
-import { searchWithoutProtectedSiren, ISearchResults } from '#models/search';
+import { ISearchResults, searchWithoutProtectedSiren } from '#models/search';
 import SearchFilterParams, { IParams } from '#models/search-filter-params';
 import { parseIntWithDefaultValue } from '#utils/helpers';
 import {
@@ -72,15 +72,10 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
 
 MapSearchResultPage.getLayout = function getLayout(
   page: ReactElement,
-  isBrowserOutdated,
   session
 ) {
   return (
-    <LayoutSearch
-      isBrowserOutdated={isBrowserOutdated}
-      map={true}
-      session={session}
-    >
+    <LayoutSearch map={true} session={session}>
       {page}
     </LayoutSearch>
   );

--- a/pages/rechercher/erreur.tsx
+++ b/pages/rechercher/erreur.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import HiddenH1 from '#components/a11y-components/hidden-h1';
 import { SearchErrorExplanations } from '#components/error-explanations';
 import { LayoutSearch } from '#components/layouts/layout-search';
@@ -39,16 +39,8 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-SearchResultPage.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated,
-  session
-) {
-  return (
-    <LayoutSearch isBrowserOutdated={isBrowserOutdated} session={session}>
-      {page}
-    </LayoutSearch>
-  );
+SearchResultPage.getLayout = function getLayout(page: ReactElement, session) {
+  return <LayoutSearch session={session}>{page}</LayoutSearch>;
 };
 
 export default SearchResultPage;

--- a/pages/rechercher/index.tsx
+++ b/pages/rechercher/index.tsx
@@ -1,13 +1,12 @@
 import { GetServerSideProps } from 'next';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import HiddenH1 from '#components/a11y-components/hidden-h1';
 import { LayoutSearch } from '#components/layouts/layout-search';
 import Meta from '#components/meta';
 import SearchResults from '#components/search-results';
 import { AdvancedSearchTutorial } from '#components/search-results/advanced-search-tutorial';
 import StructuredDataSearchAction from '#components/structured-data/search';
-import { ISearchResults } from '#models/search';
-import { searchWithoutProtectedSiren } from '#models/search';
+import { ISearchResults, searchWithoutProtectedSiren } from '#models/search';
 import SearchFilterParams, {
   IParams,
   hasSearchParam,
@@ -81,16 +80,8 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-SearchResultPage.getLayout = function getLayout(
-  page: ReactElement,
-  isBrowserOutdated,
-  session
-) {
-  return (
-    <LayoutSearch isBrowserOutdated={isBrowserOutdated} session={session}>
-      {page}
-    </LayoutSearch>
-  );
+SearchResultPage.getLayout = function getLayout(page: ReactElement, session) {
+  return <LayoutSearch session={session}>{page}</LayoutSearch>;
 };
 
 export default SearchResultPage;


### PR DESCRIPTION
This PR refactor the BrowserIsOutdatedBanner component from the layouts component into the generic one in _app.tsx

It also changes the message to present what is working instead of what is not.

### TODO 

- investigate why the warning message is displayed for IE 11 and not for firefox < 65 in prod only (it works in local and in preview apps)

### Screenshot

![image](https://github.com/etalab/annuaire-entreprises-site/assets/1775934/7a2c304c-c181-4cf8-ae49-fa11b5edf5f2)
