### PR TITLE
chore: work on retro compatibility for script

### DIFF
--- a/components/banner/browser-is-outdated.tsx
+++ b/components/banner/browser-is-outdated.tsx
@@ -39,16 +39,19 @@ export const BrowserIsOutdatedBanner: React.FC<{}> = () => (
       //  https://stackoverflow.com/questions/44891421/detect-es6-import-compatibility
       dangerouslySetInnerHTML={{
         __html: `
+        (function () {
+
           try {
-             var esModuleDisabled = typeof window !== 'undefined' 
-               && !('noModule' in HTMLScriptElement.prototype);
+            var esModuleDisabled = typeof window !== 'undefined' 
+            && !('noModule' in HTMLScriptElement.prototype);
             
-             if (esModuleDisabled) {
-                 throw new Error('browser is outdated');
-             }
+            if (esModuleDisabled) {
+              throw new Error('browser is outdated');
+            }
           } catch {
-             getElementById('browser-is-outdated').style.display = 'block';
+            document.getElementById('browser-is-outdated').style.display = 'block';
           }
+        })()
         `,
       }}
     ></script>


### PR DESCRIPTION
Work on several errors encountered in prod 

FF<60  & FF 60
- `SyntaxError: missing ( before catch`
-  `ReferenceError: getElementById is not defined`