### PR TITLE
Stop calling insee unless absolutely needed

### DIFF
--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -137,7 +137,6 @@ const mapToUniteLegale = (result: IResult): ISearchResult => {
     date_mise_a_jour = '',
     statut_diffusion = 'O',
     etablissements = [],
-    slug,
   } = result;
 
   const nomComplet = (result.nom_complet || 'Nom inconnu').toUpperCase();
@@ -310,15 +309,23 @@ const mapToEtablissement = (
     etat_administratif,
     siret
   );
+
+  let trancheEffectif = '';
+  if ('tranche_effectif_salarie' in etablissement) {
+    trancheEffectif = etablissement.tranche_effectif_salarie;
+  }
+
   return {
     ...createDefaultEtablissement(),
     siren: extractSirenFromSiret(siret),
+    enseigne,
     nic: extractNicFromSiret(siret),
     siret: verifySiret(siret),
     adresse,
     codePostal: code_postal,
     commune: libelle_commune,
     adressePostale,
+    trancheEffectif,
     latitude,
     longitude,
     estSiege: est_siege,

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -295,6 +295,8 @@ const mapToEtablissement = (
     date_creation = '',
     date_debut_activite = '',
     liste_idcc,
+    tranche_effectif_salarie = '',
+    annee_tranche_effectif_salarie = '',
   } = etablissement;
 
   const enseigne = (liste_enseignes || []).join(' ');
@@ -310,11 +312,6 @@ const mapToEtablissement = (
     siret
   );
 
-  let trancheEffectif = '';
-  if ('tranche_effectif_salarie' in etablissement) {
-    trancheEffectif = etablissement.tranche_effectif_salarie;
-  }
-
   return {
     ...createDefaultEtablissement(),
     siren: extractSirenFromSiret(siret),
@@ -325,7 +322,8 @@ const mapToEtablissement = (
     codePostal: code_postal,
     commune: libelle_commune,
     adressePostale,
-    trancheEffectif,
+    trancheEffectif: tranche_effectif_salarie,
+    anneeTrancheEffectif: annee_tranche_effectif_salarie,
     latitude,
     longitude,
     estSiege: est_siege,

--- a/clients/recherche-entreprise/interface.ts
+++ b/clients/recherche-entreprise/interface.ts
@@ -64,9 +64,10 @@ export type ISiege = {
   longitude: string;
   nom_commercial: string;
   numero_voie: string;
+  type_voie: string;
   siret: string;
   tranche_effectif_salarie: string;
-  type_voie: string;
+  annee_tranche_effectif_salarie: string;
 };
 
 export type IDirigeant = {
@@ -100,6 +101,8 @@ export type IMatchingEtablissement = {
   siret: string;
   date_creation: string;
   date_debut_activite: string;
+  tranche_effectif_salarie: string;
+  annee_tranche_effectif_salarie: string;
 };
 
 export type IComplements = {

--- a/components/etablissement-section/index.tsx
+++ b/components/etablissement-section/index.tsx
@@ -18,8 +18,12 @@ import {
   getEtablissementName,
   getNomComplet,
 } from '#models/statut-diffusion';
-import { formatDate, formatSiret } from '#utils/helpers';
-import { getCompanyLabel, getCompanyPronoun } from '#utils/helpers';
+import {
+  formatDate,
+  formatSiret,
+  getCompanyLabel,
+  getCompanyPronoun,
+} from '#utils/helpers';
 import { libelleTrancheEffectif } from '#utils/helpers/formatting/codes-effectifs';
 import { ISession } from '#utils/session';
 
@@ -145,10 +149,12 @@ const EtablissementSection: React.FC<IProps> = ({
       'Date de création de l’établissement',
       formatDate(etablissement.dateCreation),
     ],
-    [
-      'Dernière modification des données Insee',
-      formatDate(etablissement.dateDerniereMiseAJour),
-    ],
+    ...(etablissement.dateDerniereMiseAJour
+      ? [
+          'Dernière modification des données Insee',
+          formatDate(etablissement.dateDerniereMiseAJour),
+        ]
+      : []),
     ...(!estActif(etablissement)
       ? [['Date de fermeture', formatDate(etablissement.dateFermeture || '')]]
       : []),

--- a/components/etablissement-section/index.tsx
+++ b/components/etablissement-section/index.tsx
@@ -151,8 +151,10 @@ const EtablissementSection: React.FC<IProps> = ({
     ],
     ...(etablissement.dateDerniereMiseAJour
       ? [
-          'Dernière modification des données Insee',
-          formatDate(etablissement.dateDerniereMiseAJour),
+          [
+            'Dernière modification des données Insee',
+            formatDate(etablissement.dateDerniereMiseAJour),
+          ],
         ]
       : []),
     ...(!estActif(etablissement)

--- a/models/etablissement.ts
+++ b/models/etablissement.ts
@@ -3,16 +3,16 @@ import { clientEtablissementRechercheEntreprise } from '#clients/recherche-entre
 import { clientEtablissementInsee } from '#clients/sirene-insee/siret';
 import { getGeoLoc } from '#models/geo-loc';
 import { getUniteLegaleFromSlug } from '#models/unite-legale';
-import { extractSirenFromSiret, Siret, verifySiret } from '#utils/helpers';
+import { Siret, extractSirenFromSiret, verifySiret } from '#utils/helpers';
 import {
   logRechercheEntreprisefailed,
   logSireneInseefailed,
 } from '#utils/sentry/helpers';
 import {
-  createDefaultEtablissement,
   IEtablissement,
   IEtablissementWithUniteLegale,
   SiretNotFoundError,
+  createDefaultEtablissement,
 } from '.';
 
 /*
@@ -25,12 +25,11 @@ const getEtablissementFromSlug = async (
   const siret = verifySiret(slug);
 
   const isBot = options?.isBot || false;
-
   const shouldNotUseInsee = process.env.INSEE_ENABLED === 'disabled';
 
   const etablissement =
     shouldNotUseInsee || isBot
-      ? await getEtablissementForGoodBot(siret)
+      ? await getEtablissementRechercheEntreprise(siret)
       : await getEtablissement(siret);
 
   return etablissement;
@@ -93,7 +92,7 @@ const getEtablissement = async (siret: Siret): Promise<IEtablissement> => {
 /**
  * Return an Etablissement from sirene ouverte
  */
-const getEtablissementForGoodBot = async (
+const getEtablissementRechercheEntreprise = async (
   siret: Siret
 ): Promise<IEtablissement> => {
   try {
@@ -150,7 +149,7 @@ const createNonDiffusibleEtablissement = (siret: Siret) => {
 };
 
 export {
-  getEtablissementWithUniteLegaleFromSlug,
-  getEtablissementWithLatLongFromSlug,
   getEtablissementFromSlug,
+  getEtablissementWithLatLongFromSlug,
+  getEtablissementWithUniteLegaleFromSlug,
 };

--- a/utils/helpers/formatting/codes-effectifs.ts
+++ b/utils/helpers/formatting/codes-effectifs.ts
@@ -53,7 +53,7 @@ export const libelleTrancheEffectif = (
     return null;
   }
   if (!anneeTrancheEffectif) {
-    return null;
+    return `${libelle} (année de référence non renseignée)`;
   }
 
   return `${libelle}, en ${anneeTrancheEffectif}`;


### PR DESCRIPTION
L'API de l'INSEE n'est plus appelée que dans les cas suivants : 
- La nature juridique est une entreprise individuelle, il faut vérifier si elle est diffusible
- L'unité légale a plus de 10 établissements, la pagination des établissements ne fonctionne pas sur l'api de recherche

Bonus
- Quelques champs sont manquants dans l'API de recherche p/r au retour INSEE (cf  https://github.com/etalab/annuaire-entreprises-search-api/issues/310)
### Question
Le nombre d'établissement à partir duquel on appel l'insee est arbitraire : 10. Quel est la bonne valeur à mettre ?