### PR TITLE
feat: decrease sampling even further to 0.5%

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,7 +3,7 @@ import { isNextJSSentryActivated } from '#utils/sentry';
 if (isNextJSSentryActivated) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 0.01,
+    tracesSampleRate: 0.005,
     maxBreadcrumbs: 2,
   });
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,7 +3,7 @@ import { isNextJSSentryActivated } from '#utils/sentry';
 if (isNextJSSentryActivated) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 0.01,
+    tracesSampleRate: 0.005,
     maxBreadcrumbs: 0, // dont log breadcrumb
   });
 }


### PR DESCRIPTION
I see no reason to not decrease further the APM sampling : 
- it endanger the sentry instance
- the sheer volume of request make it still relevant at 0.5%