### PR TITLE
refacto: dont call ban when there already is a geoloc

### DIFF
--- a/models/etablissement.ts
+++ b/models/etablissement.ts
@@ -127,9 +127,11 @@ const getEtablissementWithLatLongFromSlug = async (
   slug: string
 ): Promise<IEtablissement> => {
   const etablissement = await getEtablissementFromSlug(slug);
-  const { lat, long } = await getGeoLoc(etablissement);
-  etablissement.latitude = lat;
-  etablissement.longitude = long;
+  if (!etablissement.latitude || !etablissement.longitude) {
+    const { lat, long } = await getGeoLoc(etablissement);
+    etablissement.latitude = lat;
+    etablissement.longitude = long;
+  }
   return etablissement;
 };
 

--- a/pages/carte/[slug].tsx
+++ b/pages/carte/[slug].tsx
@@ -45,7 +45,10 @@ const EtablissementMapPage: NextPageWithLayout<IProps> = ({
       <>
         <MapTitleEtablissement
           etablissement={etablissement}
-          title="Géolocalisation de l’établissement"
+          title={`Géolocalisation de l’établissement - ${getAdresseEtablissement(
+            etablissement,
+            session
+          )}`}
         />
         {!estDiffusible(etablissement) ? (
           <Info>


### PR DESCRIPTION
When etablissement comes from `RechercheEntreprise` no need to call BAN again