### PR TITLE
 feat: add unite legale name to link label 

### DIFF
--- a/components/annonces-section/annonces-association.tsx
+++ b/components/annonces-section/annonces-association.tsx
@@ -6,6 +6,7 @@ import { Tag } from '#components-ui/tag';
 import { DILA } from '#components/administrations';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
+import { UniteLegalePageLink } from '#components/unite-legale-page-link';
 import { EAdministration } from '#models/administrations';
 import { IAssociation } from '#models/index';
 import { formatDate } from '#utils/helpers';
@@ -48,14 +49,12 @@ const AnnoncesAssociationSection: React.FC<{
                 <b>Journal Officiel des Associations (JOAFE)</b>
                 , consolidé par la <DILA />. Pour en savoir plus, vous pouvez
                 consulter{' '}
-                <a
-                  rel="noreferrer noopener"
-                  target="_blank"
+                <UniteLegalePageLink
+                  uniteLegale={association}
                   href={`${routes.journalOfficielAssociations.site.recherche}?q=${association.siren}`}
-                >
-                  la page de cette association
-                </a>{' '}
-                sur le site du JOAFE&nbsp;:
+                  siteName="le site du JOAFE"
+                />
+                &nbsp;:
               </p>
               <FullTable
                 head={[

--- a/components/annonces-section/bodacc.tsx
+++ b/components/annonces-section/bodacc.tsx
@@ -6,6 +6,7 @@ import { Tag } from '#components-ui/tag';
 import { DILA } from '#components/administrations';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
+import { UniteLegalePageLink } from '#components/unite-legale-page-link';
 import { EAdministration } from '#models/administrations';
 import { IAnnoncesBodacc } from '#models/annonces';
 import { IAPILoading } from '#models/api-loading';
@@ -72,14 +73,12 @@ const AnnoncesBodaccSection: React.FC<{
                 </b>
                 , consolidé par la <DILA />. Pour en savoir plus, vous pouvez
                 consulter{' '}
-                <a
-                  rel="noreferrer noopener"
-                  target="_blank"
+                <UniteLegalePageLink
+                  uniteLegale={uniteLegale}
                   href={`${routes.bodacc.site.recherche}/${uniteLegale.siren}`}
-                >
-                  la page de cette entreprise
-                </a>{' '}
-                sur le site du BODACC&nbsp;:
+                  siteName="le site du BODACC"
+                />
+                &nbsp;:
               </p>
               <FullTable
                 head={['Publication', 'N°', 'Details', 'Lien']}

--- a/components/annonces-section/comptes-association.tsx
+++ b/components/annonces-section/comptes-association.tsx
@@ -5,6 +5,7 @@ import { Tag } from '#components-ui/tag';
 import { DILA } from '#components/administrations';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
+import { UniteLegalePageLink } from '#components/unite-legale-page-link';
 import { EAdministration } from '#models/administrations';
 import { IAssociation } from '#models/index';
 import { formatDate } from '#utils/helpers';
@@ -41,14 +42,12 @@ export const ComptesAssociationSection: React.FC<{
               <b>Journal Officiel des Associations (JOAFE)</b>
               , consolidé par la <DILA />. Pour en savoir plus, vous pouvez
               consulter{' '}
-              <a
-                rel="noreferrer noopener"
-                target="_blank"
+              <UniteLegalePageLink
+                uniteLegale={association}
                 href={`${routes.journalOfficielAssociations.site.recherche}?q=${association.siren}`}
-              >
-                la page de cette association
-              </a>{' '}
-              sur le site du JOAFE&nbsp;:
+                siteName="le site du JOAFE"
+              />
+              &nbsp;:
             </p>
             <FullTable
               head={[

--- a/components/dirigeants-section/beneficiaires.tsx
+++ b/components/dirigeants-section/beneficiaires.tsx
@@ -5,18 +5,20 @@ import { HorizontalSeparator } from '#components-ui/horizontal-separator';
 import { INPI } from '#components/administrations';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
+import { UniteLegalePageLink } from '#components/unite-legale-page-link';
 import { EAdministration } from '#models/administrations';
 import { IAPILoading } from '#models/api-loading';
 import { IAPINotRespondingError } from '#models/api-not-responding';
 import { IBeneficiaire, IImmatriculationRNE } from '#models/immatriculation';
-import { Siren, formatDatePartial } from '#utils/helpers';
+import { IUniteLegale } from '#models/index';
+import { formatDatePartial } from '#utils/helpers';
 
 type IProps = {
   immatriculationRNE:
     | IImmatriculationRNE
     | IAPINotRespondingError
     | IAPILoading;
-  siren: Siren;
+  uniteLegale: IUniteLegale;
 };
 
 function hasSeveralBeneficiaires(immatriculationRNE: IImmatriculationRNE) {
@@ -30,7 +32,7 @@ function hasSeveralBeneficiaires(immatriculationRNE: IImmatriculationRNE) {
  */
 const BeneficiairesSection: React.FC<IProps> = ({
   immatriculationRNE,
-  siren,
+  uniteLegale,
 }) => {
   return (
     <>
@@ -45,7 +47,7 @@ const BeneficiairesSection: React.FC<IProps> = ({
         {(immatriculationRNE) => (
           <BénéficiairesContent
             immatriculationRNE={immatriculationRNE}
-            siren={siren}
+            uniteLegale={uniteLegale}
           />
         )}
       </DataSection>
@@ -56,11 +58,11 @@ export default BeneficiairesSection;
 
 type IBeneficiairesContentProps = {
   immatriculationRNE: IImmatriculationRNE;
-  siren: Siren;
+  uniteLegale: IUniteLegale;
 };
 function BénéficiairesContent({
   immatriculationRNE,
-  siren,
+  uniteLegale,
 }: IBeneficiairesContentProps) {
   const { beneficiaires } = immatriculationRNE;
 
@@ -109,14 +111,12 @@ function BénéficiairesContent({
             enregistré{plural} au <b>Registre National des Entreprises (RNE)</b>{' '}
             tenu par l’
             <INPI />. Retrouvez le détail des modalités de contrôle sur{' '}
-            <a
-              rel="noreferrer noopener"
-              target="_blank"
-              href={`${routes.rne.portail.entreprise}${siren}`}
-            >
-              la page de cette entreprise
-            </a>{' '}
-            sur le site de l’INPI&nbsp;:
+            <UniteLegalePageLink
+              uniteLegale={uniteLegale}
+              href={`${routes.rne.portail.entreprise}${uniteLegale.siren}`}
+              siteName="le site de l’INPI"
+            />
+            &nbsp;:
           </p>
           <FullTable
             head={['Nationalité', 'Détails']}

--- a/components/dirigeants-section/rne-dirigeants.tsx
+++ b/components/dirigeants-section/rne-dirigeants.tsx
@@ -4,6 +4,7 @@ import InpiPartiallyDownWarning from '#components-ui/alerts/inpi-partially-down'
 import { INPI } from '#components/administrations';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
+import { UniteLegalePageLink } from '#components/unite-legale-page-link';
 import { EAdministration } from '#models/administrations';
 import { IAPILoading } from '#models/api-loading';
 import { IAPINotRespondingError } from '#models/api-not-responding';
@@ -12,7 +13,8 @@ import {
   IImmatriculationRNE,
   IPersonneMorale,
 } from '#models/immatriculation';
-import { Siren, formatDatePartial, formatIntFr } from '#utils/helpers';
+import { IUniteLegale } from '#models/index';
+import { formatDatePartial, formatIntFr } from '#utils/helpers';
 
 /**
  * Weird bug happennig here. Webpack build fail when this function is in model/dirigeants.ts
@@ -36,13 +38,16 @@ type IProps = {
     | IImmatriculationRNE
     | IAPINotRespondingError
     | IAPILoading;
-  siren: Siren;
+  uniteLegale: IUniteLegale;
 };
 
 /**
  * Dirigeants section
  */
-const DirigeantsSection: React.FC<IProps> = ({ immatriculationRNE, siren }) => (
+const DirigeantsSection: React.FC<IProps> = ({
+  immatriculationRNE,
+  uniteLegale,
+}) => (
   <DataSection
     id="rne-dirigeants"
     title="Dirigeant(s)"
@@ -51,7 +56,10 @@ const DirigeantsSection: React.FC<IProps> = ({ immatriculationRNE, siren }) => (
     notFoundInfo={null}
   >
     {(immatriculationRNE) => (
-      <DirigeantContent immatriculationRNE={immatriculationRNE} siren={siren} />
+      <DirigeantContent
+        immatriculationRNE={immatriculationRNE}
+        uniteLegale={uniteLegale}
+      />
     )}
   </DataSection>
 );
@@ -60,11 +68,11 @@ export default DirigeantsSection;
 
 type IDirigeantContentProps = {
   immatriculationRNE: IImmatriculationRNE;
-  siren: Siren;
+  uniteLegale: IUniteLegale;
 };
 function DirigeantContent({
   immatriculationRNE,
-  siren,
+  uniteLegale,
 }: IDirigeantContentProps) {
   const { dirigeants } = immatriculationRNE;
 
@@ -114,7 +122,7 @@ function DirigeantContent({
         ...(dirigeant.dateNaissancePartial
           ? [
               <a
-                href={`/personne?n=${dirigeant.nom}&fn=${dirigeant.prenom}&partialDate=${dirigeant.dateNaissancePartial}&sirenFrom=${siren}`}
+                href={`/personne?n=${dirigeant.nom}&fn=${dirigeant.prenom}&partialDate=${dirigeant.dateNaissancePartial}&sirenFrom=${uniteLegale.siren}`}
               >
                 → voir ses entreprises
               </a>,
@@ -144,14 +152,12 @@ function DirigeantContent({
             enregistré{plural} au <b>Registre National des Entreprises (RNE)</b>{' '}
             tenu par l’
             <INPI />. Pour en savoir plus, vous pouvez consulter{' '}
-            <a
-              rel="noreferrer noopener"
-              target="_blank"
-              href={`${routes.rne.portail.entreprise}${siren}`}
-            >
-              la page de cette entreprise
-            </a>{' '}
-            sur le site de l’INPI&nbsp;:
+            <UniteLegalePageLink
+              href={`${routes.rne.portail.entreprise}${uniteLegale.siren}`}
+              uniteLegale={uniteLegale}
+              siteName="le site de l’INPI"
+            />
+            &nbsp;:
           </p>
           <FullTable
             head={['Role', 'Details', 'Action']}

--- a/components/error-boundary/index.tsx
+++ b/components/error-boundary/index.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import React from 'react';
-import { ClientErrorExplanations } from './error-explanations';
-import { LayoutDefault } from './layouts/layout-default';
+import { ClientErrorExplanations } from '../error-explanations';
+import { LayoutDefault } from '../layouts/layout-default';
 
 export default function ErrorBoundary({
   children,

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -6,7 +6,8 @@ import { AdvancedSearch } from '#components/advanced-search';
 import SearchBar from '#components/search-bar';
 import constants from '#models/constants';
 import { IParams } from '#models/search-filter-params';
-import { ISession, isLoggedIn } from '#utils/session';
+import { isLoggedIn } from '#utils/session';
+import useSession from 'hooks/use-session';
 
 type IProps = {
   currentSearchTerm?: string;
@@ -15,7 +16,6 @@ type IProps = {
   useAdvancedSearch?: boolean;
   useLogo?: boolean;
   useSearchBar?: boolean;
-  session?: ISession | null;
 };
 
 export const Header: React.FC<IProps> = ({
@@ -25,172 +25,174 @@ export const Header: React.FC<IProps> = ({
   useLogo = false,
   useAdvancedSearch = false,
   useSearchBar = false,
-  session = null,
-}) => (
-  <>
-    <header role="banner" className="fr-header">
-      <div
-        id="loader-bar"
-        style={{
-          background: isLoggedIn(session)
-            ? constants.colors.espaceAgent
-            : 'transparent',
-        }}
-      />
-      <PrintNever>
-        <form
-          id="search-bar-form"
-          action={useMap ? '/rechercher/carte' : '/rechercher'}
-          method="get"
-        >
-          <div className="fr-header__body">
-            <div className="fr-container">
-              <div className="fr-header__body-row">
-                <div className="fr-header__brand">
-                  <div className="fr-header__brand-top">
-                    <div className="fr-header__logo">
-                      <a href="/" title="République française">
-                        <p className="fr-logo">
-                          République
-                          <br />
-                          française
-                        </p>
-                      </a>
-                    </div>
-                    {useSearchBar || useLogo ? (
-                      <div className="annuaire-logo">
-                        <a href="/" title="L’Annuaire des Entreprises">
-                          <Logo
-                            title="Logo de l’Annuaire des Entreprises"
-                            slug="annuaire-entreprises"
-                            width={140}
-                            height={54}
-                          />
+}) => {
+  const session = useSession();
+  return (
+    <>
+      <header role="banner" className="fr-header">
+        <div
+          id="loader-bar"
+          style={{
+            background: isLoggedIn(session)
+              ? constants.colors.espaceAgent
+              : 'transparent',
+          }}
+        />
+        <PrintNever>
+          <form
+            id="search-bar-form"
+            action={useMap ? '/rechercher/carte' : '/rechercher'}
+            method="get"
+          >
+            <div className="fr-header__body">
+              <div className="fr-container">
+                <div className="fr-header__body-row">
+                  <div className="fr-header__brand">
+                    <div className="fr-header__brand-top">
+                      <div className="fr-header__logo">
+                        <a href="/" title="République française">
+                          <p className="fr-logo">
+                            République
+                            <br />
+                            française
+                          </p>
                         </a>
                       </div>
-                    ) : null}
-                    <div className="fr-header__navbar"></div>
-                  </div>
-                  {useSearchBar ? (
-                    <div className="not-fr-search">
-                      <SearchBar defaultValue={currentSearchTerm} />
-                    </div>
-                  ) : null}
-                </div>
-                <div className="fr-header__tools">
-                  <div className="fr-header__tools-links">
-                    {isLoggedIn(session) ? (
-                      <ul className="fr-links-group">
-                        <li>
-                          <a
-                            className="fr-link menu-logout"
-                            href="/api/auth/mon-compte-pro/logout"
-                          >
-                            <div>
-                              <Icon slug="user">
-                                {session?.user?.fullName ||
-                                  session?.user?.email ||
-                                  'Utilisateur inconnu'}
-                                &nbsp;(
-                                <b
-                                  style={{
-                                    fontVariant: 'small-caps',
-                                    color: constants.colors.espaceAgent,
-                                  }}
-                                >
-                                  agent public
-                                </b>
-                                )
-                              </Icon>
-                            </div>
-                            <div>Se déconnecter</div>
+                      {useSearchBar || useLogo ? (
+                        <div className="annuaire-logo">
+                          <a href="/" title="L’Annuaire des Entreprises">
+                            <Logo
+                              title="Logo de l’Annuaire des Entreprises"
+                              slug="annuaire-entreprises"
+                              width={140}
+                              height={54}
+                            />
                           </a>
-                        </li>
-                      </ul>
+                        </div>
+                      ) : null}
+                      <div className="fr-header__navbar"></div>
+                    </div>
+                    {useSearchBar ? (
+                      <div className="not-fr-search">
+                        <SearchBar defaultValue={currentSearchTerm} />
+                      </div>
                     ) : null}
+                  </div>
+                  <div className="fr-header__tools">
+                    <div className="fr-header__tools-links">
+                      {isLoggedIn(session) ? (
+                        <ul className="fr-links-group">
+                          <li>
+                            <a
+                              className="fr-link menu-logout"
+                              href="/api/auth/mon-compte-pro/logout"
+                            >
+                              <div>
+                                <Icon slug="user">
+                                  {session?.user?.fullName ||
+                                    session?.user?.email ||
+                                    'Utilisateur inconnu'}
+                                  &nbsp;(
+                                  <b
+                                    style={{
+                                      fontVariant: 'small-caps',
+                                      color: constants.colors.espaceAgent,
+                                    }}
+                                  >
+                                    agent public
+                                  </b>
+                                  )
+                                </Icon>
+                              </div>
+                              <div>Se déconnecter</div>
+                            </a>
+                          </li>
+                        </ul>
+                      ) : null}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          {useAdvancedSearch ? (
-            <AdvancedSearch
-              searchParams={searchParams}
-              currentSearchTerm={currentSearchTerm}
-              isMap={useMap}
-            />
-          ) : null}
-        </form>
-      </PrintNever>
-    </header>
-    <style jsx>{`
-      ${!useSearchBar
-        ? `header.fr-header, div.fr-header__brand {
+            {useAdvancedSearch ? (
+              <AdvancedSearch
+                searchParams={searchParams}
+                currentSearchTerm={currentSearchTerm}
+                isMap={useMap}
+              />
+            ) : null}
+          </form>
+        </PrintNever>
+      </header>
+      <style jsx>{`
+        ${!useSearchBar
+          ? `header.fr-header, div.fr-header__brand {
         filter: none !important;
       }`
-        : ''}
+          : ''}
 
-      div.annuaire-logo {
-        order: 2;
-        margin-right: 15px;
-      }
-
-      .not-fr-search {
-        width: 470px;
-        max-width: 100%;
-        flex-grow: 1;
-      }
-
-      div.with-session-banner {
-        background-color: ${constants.colors.espaceAgent};
-        color: #fff;
-        font-size: 2rem;
-        line-height: 3rem;
-      }
-
-      #loader-bar {
-        transition: width 150ms ease-in-out;
-        width: 100%;
-        height: 3px;
-        top: 0;
-        left: 0;
-        z-index: 1000;
-        position: absolute;
-      }
-
-      a.menu-logout {
-        position: relative;
-      }
-      a.menu-logout div:last-of-type {
-        position: absolute;
-        top: 100%;
-        left: 0;
-        display: none;
-        width: 100%;
-        background-color: #fff;
-        padding: 5px 15px;
-        box-shadow: 0 10px 20px -10px rgba(0, 0, 0, 0.35);
-      }
-      a.menu-logout div:last-of-type:hover {
-        background-color: #fbfbfb;
-      }
-
-      a.menu-logout:hover div:last-of-type {
-        display: block;
-      }
-
-      @media print {
-        .fr-header {
-          display: none !important;
+        div.annuaire-logo {
+          order: 2;
+          margin-right: 15px;
         }
-      }
-      @media only screen and (min-width: 1px) and (max-width: 992px) {
+
         .not-fr-search {
-          width: 100%;
-          margin: 0.75rem;
-          margin-top: 0;
+          width: 470px;
+          max-width: 100%;
+          flex-grow: 1;
         }
-      }
-    `}</style>
-  </>
-);
+
+        div.with-session-banner {
+          background-color: ${constants.colors.espaceAgent};
+          color: #fff;
+          font-size: 2rem;
+          line-height: 3rem;
+        }
+
+        #loader-bar {
+          transition: width 150ms ease-in-out;
+          width: 100%;
+          height: 3px;
+          top: 0;
+          left: 0;
+          z-index: 1000;
+          position: absolute;
+        }
+
+        a.menu-logout {
+          position: relative;
+        }
+        a.menu-logout div:last-of-type {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          display: none;
+          width: 100%;
+          background-color: #fff;
+          padding: 5px 15px;
+          box-shadow: 0 10px 20px -10px rgba(0, 0, 0, 0.35);
+        }
+        a.menu-logout div:last-of-type:hover {
+          background-color: #fbfbfb;
+        }
+
+        a.menu-logout:hover div:last-of-type {
+          display: block;
+        }
+
+        @media print {
+          .fr-header {
+            display: none !important;
+          }
+        }
+        @media only screen and (min-width: 1px) and (max-width: 992px) {
+          .not-fr-search {
+            width: 100%;
+            margin: 0.75rem;
+            margin-top: 0;
+          }
+        }
+      `}</style>
+    </>
+  );
+};

--- a/components/layouts/layout-default.tsx
+++ b/components/layouts/layout-default.tsx
@@ -5,17 +5,14 @@ import Footer from '#components/footer';
 import { Header } from '#components/header';
 import { WeNeedYouModal } from '#components/modal/we-need-you';
 import SocialNetworks from '#components/social-network';
-import { ISession } from '#utils/session';
 
 type IProps = {
   searchBar?: boolean;
-  session?: ISession | null;
 };
 
 export const LayoutDefault = ({
   children,
   searchBar = true,
-  session = null,
 }: PropsWithChildren<IProps>) => {
   return (
     <div id="page-layout">
@@ -26,7 +23,6 @@ export const LayoutDefault = ({
         useSearchBar={searchBar}
         useAdvancedSearch={false}
         useMap={false}
-        session={session}
       />
       <main className="fr-container">{children}</main>
       <SocialNetworks />

--- a/components/layouts/layout-search.tsx
+++ b/components/layouts/layout-search.tsx
@@ -7,24 +7,18 @@ import { Header } from '#components/header';
 import { WeNeedYouModal } from '#components/modal/we-need-you';
 import SocialNetworks from '#components/social-network';
 import { IParams } from '#models/search-filter-params';
-import { ISession } from '#utils/session';
 
 type IProps = {
   currentSearchTerm?: string;
   map?: boolean;
   searchFilterParams?: IParams;
-  session?: ISession | null;
 };
 
 /**
  * This Layout should be use only for the page /recherche and /rechercher/carte who use
  * advanced filter with react activated
  */
-export const LayoutSearch = ({
-  children,
-  map,
-  session = null,
-}: PropsWithChildren<IProps>) => {
+export const LayoutSearch = ({ children, map }: PropsWithChildren<IProps>) => {
   const router = useRouter();
   const { terme, ...rest } = router.query;
 
@@ -40,7 +34,6 @@ export const LayoutSearch = ({
         useAdvancedSearch={true}
         useSearchBar={true}
         useLogo={true}
-        session={session}
       />
 
       <main className="fr-container">{children}</main>

--- a/components/layouts/layout-simple.tsx
+++ b/components/layouts/layout-simple.tsx
@@ -1,20 +1,14 @@
 import React, { PropsWithChildren } from 'react';
 import Footer from '#components/footer';
 import { Header } from '#components/header';
-import { ISession } from '#utils/session';
 
-export const LayoutSimple: React.FC<
-  PropsWithChildren<{
-    session: ISession | null | undefined;
-  }>
-> = ({ children, session }) => (
+export const LayoutSimple: React.FC<PropsWithChildren<{}>> = ({ children }) => (
   <div id="page-layout">
     <Header
       useSearchBar={false}
       useLogo={true}
       useAdvancedSearch={false}
       useMap={false}
-      session={session}
     />
     <main className="fr-container">{children}</main>
     <Footer />

--- a/components/unite-legale-page-link/index.tsx
+++ b/components/unite-legale-page-link/index.tsx
@@ -1,0 +1,40 @@
+import { IUniteLegale, isAssociation } from '#models/index';
+import { getNomComplet } from '#models/statut-diffusion';
+import useSession from 'hooks/use-session';
+
+type IProp = {
+  /**
+   * The unite legale to use for the link label.
+   */
+  uniteLegale: IUniteLegale;
+  /**
+   * The href attribute for the link. Ex : /entreprise/123456789.
+   */
+  href: string;
+  /**
+   * If external link, the site name for the link label (ex: "le site de l'INSEE" / "association.gouv.fr").
+   */
+  siteName?: string;
+};
+
+export function UniteLegalePageLink({ uniteLegale, href, siteName }: IProp) {
+  const session = useSession();
+  const nomComplet = getNomComplet(uniteLegale, session);
+  const linkLabel = isAssociation(uniteLegale)
+    ? `la page de l’association ${nomComplet}`
+    : `la page de l’entreprise ${nomComplet}`;
+  const siteDescription = siteName ? ` sur ${siteName}` : '';
+  return (
+    <>
+      <a
+        href={href}
+        aria-label={`Voir ${linkLabel}${siteDescription}`}
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        {linkLabel}
+      </a>
+      {siteDescription}
+    </>
+  );
+}

--- a/hooks/use-session.ts
+++ b/hooks/use-session.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+import { ISession } from '#utils/session';
+
+const sessionContext = createContext<ISession | null>(null);
+export default function useSession(): ISession | null {
+  return useContext(sessionContext);
+}
+
+export const SessionProvider = sessionContext.Provider;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,13 +2,14 @@ import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import type { ReactElement, ReactNode } from 'react';
 import { BrowserIsOutdatedBanner } from '#components/banner/browser-is-outdated';
-import ErrorBoundary from '#components/error-boundary';
+import ErrorBoundary from '#components/error-boundary/index';
 import { LayoutDefault } from '#components/layouts/layout-default';
 import { ISession } from '#utils/session';
+import { SessionProvider } from 'hooks/use-session';
 import '../frontend/src/entry-with-react';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement, session?: ISession | null) => ReactNode;
+  getLayout?: (page: ReactElement) => ReactNode;
 };
 
 type AppPropsWithLayout = AppProps & {
@@ -16,17 +17,18 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  const session = pageProps?.metadata?.session || null;
+  const session: ISession | null = pageProps?.metadata?.session || null;
   // Use the layout defined at the page level, otherwise fallback on layout with default settings.
   const getLayout =
-    Component.getLayout ??
-    ((page) => <LayoutDefault session={session}>{page}</LayoutDefault>);
+    Component.getLayout ?? ((page) => <LayoutDefault>{page}</LayoutDefault>);
   //eslint-disable-next-line react/jsx-props-no-spreading
-  const layout = getLayout(<Component {...pageProps} />, session);
+  const layout = getLayout(<Component {...pageProps} />);
   return (
     <ErrorBoundary>
-      <BrowserIsOutdatedBanner />
-      {layout}
+      <SessionProvider value={session}>
+        <BrowserIsOutdatedBanner />
+        {layout}
+      </SessionProvider>
     </ErrorBoundary>
   );
 }

--- a/pages/dirigeants/[slug].tsx
+++ b/pages/dirigeants/[slug].tsx
@@ -66,12 +66,12 @@ const DirigeantsPage: NextPageWithLayout<IProps> = ({
 
               <DirigeantsSection
                 immatriculationRNE={immatriculationRNE}
-                siren={uniteLegale.siren}
+                uniteLegale={uniteLegale}
               />
               <BreakPageForPrint />
               <BeneficiairesSection
                 immatriculationRNE={immatriculationRNE}
-                siren={uniteLegale.siren}
+                uniteLegale={uniteLegale}
               />
             </>
           ) : (

--- a/pages/entreprise/[slug].tsx
+++ b/pages/entreprise/[slug].tsx
@@ -32,6 +32,7 @@ import {
   postServerSideProps,
 } from '#utils/server-side-props-helper/post-server-side-props';
 import { isAgent, isSuperAgent } from '#utils/session';
+import useSession from 'hooks/use-session';
 import { NextPageWithLayout } from 'pages/_app';
 
 interface IProps extends IPropsWithMetadata {
@@ -42,68 +43,69 @@ interface IProps extends IPropsWithMetadata {
 const UniteLegalePage: NextPageWithLayout<IProps> = ({
   uniteLegale,
   redirected,
-  metadata: { session },
-}) => (
-  <>
-    <Meta
-      title={getCompanyPageTitle(uniteLegale, session)}
-      description={getCompanyPageDescription(uniteLegale, session)}
-      noIndex={shouldNotIndex(uniteLegale)}
-      canonical={`https://annuaire-entreprises.data.gouv.fr/entreprise/${
-        uniteLegale.chemin || uniteLegale.siren
-      }`}
-    />
-    {redirected && <MatomoEventRedirected sirenOrSiret={uniteLegale.siren} />}
-
-    {isAgent(session) && (
-      <MatomoEvent
-        category="espace-agent"
-        action={`${isSuperAgent(session) ? 'super-agent' : 'agent'}`}
-        name={`visit:${uniteLegale.siren}`}
+}) => {
+  const session = useSession();
+  return (
+    <>
+      <Meta
+        title={getCompanyPageTitle(uniteLegale, session)}
+        description={getCompanyPageDescription(uniteLegale, session)}
+        noIndex={shouldNotIndex(uniteLegale)}
+        canonical={`https://annuaire-entreprises.data.gouv.fr/entreprise/${
+          uniteLegale.chemin || uniteLegale.siren
+        }`}
       />
-    )}
+      {redirected && <MatomoEventRedirected sirenOrSiret={uniteLegale.siren} />}
 
-    <StructuredDataBreadcrumb uniteLegale={uniteLegale} />
-    <div className="content-container">
-      <Title
-        uniteLegale={uniteLegale}
-        ficheType={FICHE.INFORMATION}
-        session={session}
-      />
-      {estNonDiffusible(uniteLegale) ? (
-        <NonDiffusibleSection />
-      ) : (
-        <>
-          <UniteLegaleSection uniteLegale={uniteLegale} session={session} />
-          {isSuperAgent(session) ? (
-            <EspaceAgentSummarySection uniteLegale={uniteLegale} />
-          ) : null}
-          {isAssociation(uniteLegale) && (
-            <AssociationSection uniteLegale={uniteLegale} />
-          )}
-          {isCollectiviteTerritoriale(uniteLegale) && (
-            <CollectiviteTerritorialeSection uniteLegale={uniteLegale} />
-          )}
-          <UsefulShortcuts uniteLegale={uniteLegale} />
-          {uniteLegale.siege && (
-            <EtablissementSection
+      {isAgent(session) && (
+        <MatomoEvent
+          category="espace-agent"
+          action={`${isSuperAgent(session) ? 'super-agent' : 'agent'}`}
+          name={`visit:${uniteLegale.siren}`}
+        />
+      )}
+
+      <StructuredDataBreadcrumb uniteLegale={uniteLegale} />
+      <div className="content-container">
+        <Title
+          uniteLegale={uniteLegale}
+          ficheType={FICHE.INFORMATION}
+          session={session}
+        />
+        {estNonDiffusible(uniteLegale) ? (
+          <NonDiffusibleSection />
+        ) : (
+          <>
+            <UniteLegaleSection uniteLegale={uniteLegale} session={session} />
+            {isSuperAgent(session) ? (
+              <EspaceAgentSummarySection uniteLegale={uniteLegale} />
+            ) : null}
+            {isAssociation(uniteLegale) && (
+              <AssociationSection uniteLegale={uniteLegale} />
+            )}
+            {isCollectiviteTerritoriale(uniteLegale) && (
+              <CollectiviteTerritorialeSection uniteLegale={uniteLegale} />
+            )}
+            <UsefulShortcuts uniteLegale={uniteLegale} />
+            {uniteLegale.siege && (
+              <EtablissementSection
+                uniteLegale={uniteLegale}
+                etablissement={uniteLegale.siege}
+                usedInEntreprisePage={true}
+                withDenomination={false}
+                session={session}
+              />
+            )}
+            <EtablissementListeSection
               uniteLegale={uniteLegale}
-              etablissement={uniteLegale.siege}
-              usedInEntreprisePage={true}
-              withDenomination={false}
               session={session}
             />
-          )}
-          <EtablissementListeSection
-            uniteLegale={uniteLegale}
-            session={session}
-          />
-        </>
-      )}
-    </div>
-  </>
-);
-
+          </>
+        )}
+      </div>
+    </>
+  );
+};
 export const getServerSideProps: GetServerSideProps = postServerSideProps(
   async (context) => {
     const { slug, isRedirected, page, isBot } =

--- a/pages/faq/parcours.tsx
+++ b/pages/faq/parcours.tsx
@@ -319,8 +319,8 @@ const Parcours: NextPageWithLayout<{
   );
 };
 
-Parcours.getLayout = function getLayout(page: ReactElement, session) {
-  return <LayoutSimple session={session}>{page}</LayoutSimple>;
+Parcours.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutSimple>{page}</LayoutSimple>;
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,12 +72,10 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-Index.getLayout = function getLayout(page: ReactElement, session) {
+Index.getLayout = function getLayout(page: ReactElement) {
   return (
     <>
-      <LayoutDefault searchBar={false} session={session}>
-        {page}
-      </LayoutDefault>
+      <LayoutDefault searchBar={false}>{page}</LayoutDefault>
     </>
   );
 };

--- a/pages/rechercher/carte.tsx
+++ b/pages/rechercher/carte.tsx
@@ -69,15 +69,8 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-MapSearchResultPage.getLayout = function getLayout(
-  page: ReactElement,
-  session
-) {
-  return (
-    <LayoutSearch map={true} session={session}>
-      {page}
-    </LayoutSearch>
-  );
+MapSearchResultPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutSearch map={true}>{page}</LayoutSearch>;
 };
 
 export default MapSearchResultPage;

--- a/pages/rechercher/erreur.tsx
+++ b/pages/rechercher/erreur.tsx
@@ -39,8 +39,8 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-SearchResultPage.getLayout = function getLayout(page: ReactElement, session) {
-  return <LayoutSearch session={session}>{page}</LayoutSearch>;
+SearchResultPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutSearch>{page}</LayoutSearch>;
 };
 
 export default SearchResultPage;

--- a/pages/rechercher/index.tsx
+++ b/pages/rechercher/index.tsx
@@ -80,8 +80,8 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
   }
 );
 
-SearchResultPage.getLayout = function getLayout(page: ReactElement, session) {
-  return <LayoutSearch session={session}>{page}</LayoutSearch>;
+SearchResultPage.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutSearch>{page}</LayoutSearch>;
 };
 
 export default SearchResultPage;


### PR DESCRIPTION
- create a new component UniteLegalePageLink
- use it in the dirigeants and annonces sections
- add a `useSession` hook to get the session from anywhere

fix #720
