### PR TITLE
refactor: move TVA logic into uniteLegale model

### DIFF
--- a/components/etablissement-section/index.tsx
+++ b/components/etablissement-section/index.tsx
@@ -118,7 +118,7 @@ const EtablissementSection: React.FC<IProps> = ({
                 Comprendre le numéro de TVA intracommunautaire
               </a>
             </FAQLink>,
-            <TVACell uniteLegale={uniteLegale} />,
+            <TVACell tva={uniteLegale.tva} />,
           ],
         ]
       : []),

--- a/components/unite-legale-section/index.tsx
+++ b/components/unite-legale-section/index.tsx
@@ -46,7 +46,7 @@ const UniteLegaleSection: React.FC<{
           Comprendre le numéro de TVA intracommunautaire
         </a>
       </FAQLink>,
-      <TVACell uniteLegale={uniteLegale} />,
+      <TVACell tva={uniteLegale.tva} />,
     ],
     ['Activité principale (NAF/APE)', uniteLegale.libelleActivitePrincipale],
     ['Code NAF/APE', uniteLegale.activitePrincipale],

--- a/models/index.ts
+++ b/models/index.ts
@@ -8,6 +8,7 @@ import { IEtatCivil } from '#models/immatriculation';
 import { IdRna, Siren, Siret } from '#utils/helpers';
 import { IAPINotRespondingError } from './api-not-responding';
 import { ISTATUTDIFFUSION } from './statut-diffusion';
+import { ITVAIntracommunautaire } from './tva';
 
 export interface IConventionCollective {
   idcc: string;
@@ -85,6 +86,7 @@ export const createDefaultEtablissement = (): IEtablissement => {
 export interface IUniteLegale extends IEtablissementsList {
   siren: Siren;
   oldSiren: Siren;
+  tva: ITVAIntracommunautaire | null;
   siege: IEtablissement;
   allSiegesSiret: Siret[];
   natureJuridique: string;
@@ -122,6 +124,7 @@ export const createDefaultUniteLegale = (siren: Siren): IUniteLegale => {
     oldSiren: siren,
     siege,
     allSiegesSiret: [],
+    tva: null,
     statutDiffusion: ISTATUTDIFFUSION.DIFFUSIBLE,
     etatAdministratif: IETATADMINSTRATIF.INCONNU,
     nomComplet: '',

--- a/models/tva/verfify.ts
+++ b/models/tva/verfify.ts
@@ -1,0 +1,32 @@
+import { TVAUserException, clientTVA } from '#clients/api-vies';
+import { HttpConnectionReset } from '#clients/exceptions';
+import { verifySiren } from '#utils/helpers';
+import { logWarningInSentry } from '#utils/sentry';
+import { tvaNumber } from './utils';
+
+/**
+ * build TVA number from siren and then validate it
+ */
+export const verifyTVA = async (slug: string): Promise<string | null> => {
+  const siren = verifySiren(slug);
+  const tvaNumberFromSiren = tvaNumber(siren);
+
+  try {
+    return await clientTVA(tvaNumberFromSiren);
+  } catch (eFirstTry: any) {
+    if (eFirstTry instanceof TVAUserException) {
+      throw eFirstTry;
+    }
+    // retry once as VIES randomely reset connection
+    try {
+      if (eFirstTry instanceof HttpConnectionReset) {
+        logWarningInSentry('ECONNRESET in API TVA : retrying');
+      } else {
+        logWarningInSentry('Error in API TVA : retrying');
+      }
+      return await clientTVA(tvaNumberFromSiren);
+    } catch (eFallback: any) {
+      throw eFallback;
+    }
+  }
+};

--- a/models/unite-legale.ts
+++ b/models/unite-legale.ts
@@ -37,6 +37,7 @@ import {
 } from './api-not-responding';
 import constants from './constants';
 import { ISTATUTDIFFUSION } from './statut-diffusion';
+import { getTvaUniteLegale } from './tva';
 
 /**
  * PUBLIC METHODS
@@ -73,6 +74,9 @@ class UniteLegaleBuilder {
 
   build = async () => {
     const uniteLegale = await this.fetchFromClients();
+
+    // determine TVA
+    uniteLegale.tva = getTvaUniteLegale(uniteLegale);
 
     // no need to call API association for bots
     if (!this._isBot && isAssociation(uniteLegale)) {

--- a/pages/api/data-fetching/verify-tva/[slug].ts
+++ b/pages/api/data-fetching/verify-tva/[slug].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { tvaIntracommunautaire } from '#models/tva';
+import { verifyTVA } from '#models/tva/verfify';
 import logErrorInSentry from '#utils/sentry';
 import { withAPM } from '#utils/sentry/tracing';
 import withAntiBot from '#utils/session/with-anti-bot';
@@ -9,7 +9,7 @@ const verify = async (
   res: NextApiResponse
 ) => {
   try {
-    const tva = await tvaIntracommunautaire(slug as string);
+    const tva = await verifyTVA(slug as string);
     res.status(200).json({ tva });
   } catch (e: any) {
     logErrorInSentry(e, { errorName: 'Error in API TVA' });


### PR DESCRIPTION
Quick refactoring following a call with @skelz0r. Moves the TVA business logic into the model instead of having it in the view