### PR TITLE
Revamp RNA architecture

### DIFF
--- a/clients/sirene-insee/siren.ts
+++ b/clients/sirene-insee/siren.ts
@@ -214,7 +214,6 @@ const mapToDomainObject = (
     },
     association: {
       idAssociation: identifiantAssociationUniteLegale || null,
-      data: null,
     },
   };
 };

--- a/components-ui/alerts/association-adress.tsx
+++ b/components-ui/alerts/association-adress.tsx
@@ -21,7 +21,7 @@ const AssociationAdressAlert: React.FC<{
 
   return (
     <>
-      {true && (
+      {adresseInconsistency && (
         <Warning full>
           L’adresse déclarée auprès du <MI /> (en préfecture){' '}
           <b>est différente</b> de celle déclarée auprès de l’

--- a/components-ui/alerts/association-adress.tsx
+++ b/components-ui/alerts/association-adress.tsx
@@ -1,39 +1,42 @@
 import { INSEE, MI } from '#components/administrations';
-import { isAPINotResponding } from '#models/api-not-responding';
-import { IAssociation } from '#models/index';
+import {
+  IAPINotRespondingError,
+  isAPINotResponding,
+} from '#models/api-not-responding';
+import { IAssociation, IDataAssociation } from '#models/index';
 import { getAdresseUniteLegale } from '#models/statut-diffusion';
-import { ISession } from '#utils/session';
 import Warning from './warning';
 
 const AssociationAdressAlert: React.FC<{
   uniteLegale: IAssociation;
-  session: ISession | null;
-}> = ({ uniteLegale, session }) => {
-  if (
-    !uniteLegale.association.data ||
-    isAPINotResponding(uniteLegale.association.data)
-  ) {
+  association: IDataAssociation | IAPINotRespondingError | null;
+}> = ({ uniteLegale, association }) => {
+  if (!association || isAPINotResponding(association)) {
     return null;
   }
 
-  const adresseInconsistency =
-    uniteLegale.association?.data?.adresseInconsistency;
+  const adresseInconsistency = association.adresseInconsistency;
 
-  const associationAdresse = uniteLegale.association?.data?.adresseSiege;
+  const associationAdresse = association.adresseSiege;
 
   return (
     <>
-      {adresseInconsistency && (
+      {true && (
         <Warning full>
-          Cette association possède deux adresses différentes.
-          <br />
-          L’une est déclarée au <MI /> (en préfecture) :{' '}
-          <b>{associationAdresse || 'Non renseignée'}</b>, l’autre est déclarée
-          à l’
-          <INSEE /> : <b>{getAdresseUniteLegale(uniteLegale, session)}</b>.
-          <br />
+          L’adresse déclarée auprès du <MI /> (en préfecture){' '}
+          <b>est différente</b> de celle déclarée auprès de l’
+          <INSEE /> :
+          <ul>
+            <li>
+              <MI /> : {associationAdresse || 'Non renseignée'}
+            </li>
+            <li>
+              <INSEE /> : {getAdresseUniteLegale(uniteLegale, null)}
+            </li>
+          </ul>
           Si vous êtes membre de cette association. Contactez l’administration
           concernée pour corriger l’erreur.
+          <br />
           <br />
           <b>NB :</b> si vous avez déjà effectué la correction auprès du <MI />,
           sachez qu’elle peut prendre quelques semaines avant d’être prise en

--- a/components-ui/alerts/association-creation-not-found-alert.tsx
+++ b/components-ui/alerts/association-creation-not-found-alert.tsx
@@ -5,15 +5,15 @@ import { formatIntFr } from '#utils/helpers';
 import Warning from './warning';
 
 const AssociationCreationNotFoundAlert: React.FC<{
-  association: IAssociation;
-}> = ({ association }) => (
+  uniteLegale: IAssociation;
+}> = ({ uniteLegale }) => (
   <Warning full>
     Nous n’avons pas retrouvé l’annonce de création de cette association dans le{' '}
     <b>Journal Officiel des Association (JOAFE).</b>
     <br />
     Les annonces les plus anciennes du Journal Officiel peuvent contenir des
     erreurs de saisie qui ne nous permettent pas de les retrouver grâce à leur
-    numéro RNA ({formatIntFr(association.association?.idAssociation || '')}).
+    numéro RNA ({formatIntFr(uniteLegale.association?.idAssociation || '')}).
     <br />
     En revanche, vous pouvez probablement retrouver l’annonce de création grâce
     au{' '}

--- a/components/annonces-section/annonces-association.tsx
+++ b/components/annonces-section/annonces-association.tsx
@@ -13,9 +13,9 @@ import { formatDate } from '#utils/helpers';
 import { useFetchJOAFE } from 'hooks';
 
 const AnnoncesAssociationSection: React.FC<{
-  association: IAssociation;
-}> = ({ association }) => {
-  const annoncesAssociation = useFetchJOAFE(association);
+  uniteLegale: IAssociation;
+}> = ({ uniteLegale }) => {
+  const annoncesAssociation = useFetchJOAFE(uniteLegale);
   return (
     <DataSection
       title="Annonces Journal Officiel des Associations"
@@ -27,7 +27,7 @@ const AnnoncesAssociationSection: React.FC<{
           {annoncesAssociation.annonces.filter(
             (annonce) => annonce.typeAvisLibelle === 'Création'
           ).length === 0 && (
-            <AssociationCreationNotFoundAlert association={association} />
+            <AssociationCreationNotFoundAlert uniteLegale={uniteLegale} />
           )}
           {annoncesAssociation.annonces.length === 0 ? (
             <div>
@@ -50,8 +50,8 @@ const AnnoncesAssociationSection: React.FC<{
                 , consolidé par la <DILA />. Pour en savoir plus, vous pouvez
                 consulter{' '}
                 <UniteLegalePageLink
-                  uniteLegale={association}
-                  href={`${routes.journalOfficielAssociations.site.recherche}?q=${association.siren}`}
+                  uniteLegale={uniteLegale}
+                  href={`${routes.journalOfficielAssociations.site.recherche}?q=${uniteLegale.siren}`}
                   siteName="le site du JOAFE"
                 />
                 &nbsp;:

--- a/components/annonces-section/comptes-association.tsx
+++ b/components/annonces-section/comptes-association.tsx
@@ -12,9 +12,9 @@ import { formatDate } from '#utils/helpers';
 import { useFetchComptesAssociation } from 'hooks';
 
 export const ComptesAssociationSection: React.FC<{
-  association: IAssociation;
-}> = ({ association }) => {
-  const comptesAssociation = useFetchComptesAssociation(association);
+  uniteLegale: IAssociation;
+}> = ({ uniteLegale }) => {
+  const comptesAssociation = useFetchComptesAssociation(uniteLegale);
   return (
     <DataSection
       data={comptesAssociation}
@@ -43,8 +43,8 @@ export const ComptesAssociationSection: React.FC<{
               , consolidé par la <DILA />. Pour en savoir plus, vous pouvez
               consulter{' '}
               <UniteLegalePageLink
-                uniteLegale={association}
-                href={`${routes.journalOfficielAssociations.site.recherche}?q=${association.siren}`}
+                uniteLegale={uniteLegale}
+                href={`${routes.journalOfficielAssociations.site.recherche}?q=${uniteLegale.siren}`}
                 siteName="le site du JOAFE"
               />
               &nbsp;:

--- a/components/association-section/index.tsx
+++ b/components/association-section/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AssociationAdressAlert from '#components-ui/alerts/association-adress';
 import Warning from '#components-ui/alerts/warning';
 import { HorizontalSeparator } from '#components-ui/horizontal-separator';
 import BreakPageForPrint from '#components-ui/print-break-page';
@@ -7,6 +8,7 @@ import { Section } from '#components/section';
 import { DataSection } from '#components/section/data-section';
 import { TwoColumnTable } from '#components/table/simple';
 import { EAdministration } from '#models/administrations/EAdministration';
+import { IAPINotRespondingError } from '#models/api-not-responding';
 import { IAssociation, IDataAssociation } from '#models/index';
 import { IdRna, formatDate, formatIntFr } from '#utils/helpers';
 import { isTwoMonthOld } from '#utils/helpers/checks';
@@ -37,14 +39,14 @@ const AssociationNotFound: React.FC<{
 
 export default function AssociationSection({
   uniteLegale,
+  association,
 }: {
   uniteLegale: IAssociation;
+  association: IDataAssociation | IAPINotRespondingError | null;
 }) {
-  const {
-    association: { idAssociation = '', data },
-  } = uniteLegale;
+  const { idAssociation = '' } = uniteLegale.association;
 
-  if (!data) {
+  if (!association) {
     // Data can be null if the natureJuridique is an association,
     // but no idAssociation is provided by Insee API call.
     return (
@@ -62,19 +64,21 @@ export default function AssociationSection({
       <DataSection
         title="Répertoire National des Associations"
         sources={[EAdministration.MI]}
-        data={data}
+        data={association}
         notFoundInfo={<AssociationNotFound uniteLegale={uniteLegale} />}
       >
-        {(data) => (
+        {(association) => (
           <>
+            <AssociationAdressAlert
+              uniteLegale={uniteLegale}
+              association={association}
+            />
             <p>
               Cette structure est inscrite au{' '}
               <b>Répertoire National des Associations (RNA)</b>, avec les
               informations suivantes&nbsp;:
             </p>
-            <TwoColumnTable
-              body={getTableData(uniteLegale.association.idAssociation, data)}
-            />
+            <TwoColumnTable body={getTableData(idAssociation, association)} />
             {idAssociation && (
               <>
                 <br />

--- a/components/finances-section/association/index.tsx
+++ b/components/finances-section/association/index.tsx
@@ -7,7 +7,7 @@ import {
   isAPINotResponding,
 } from '#models/api-not-responding';
 import constants from '#models/constants';
-import { IAssociation } from '#models/index';
+import { IDataAssociation } from '#models/index';
 import { formatCurrency } from '#utils/helpers';
 
 const ColorCircle = ({ color }: { color: string }) => (
@@ -17,10 +17,16 @@ const ColorCircle = ({ color }: { color: string }) => (
 const colorResultat = constants.chartColors[1];
 const colorCA = constants.chartColors[4];
 
+/**
+ * We use to have finances for association but data disappeared from open data API.
+ *
+ * @param param0
+ * @returns
+ */
 export const FinancesAssociationSection: React.FC<{
-  association: IAssociation;
+  association: IDataAssociation;
 }> = ({ association }) => {
-  const { data } = association.association;
+  const data = association;
   const financesAssociation =
     (!!data &&
       !isAPINotResponding(data) &&

--- a/components/immatriculations/index.tsx
+++ b/components/immatriculations/index.tsx
@@ -56,7 +56,7 @@ const Immatriculations: React.FC<IProps> = ({
         <>
           {isAssociation(uniteLegale) ? (
             <>
-              <AssociationCreationNotFoundAlert association={uniteLegale} />
+              <AssociationCreationNotFoundAlert uniteLegale={uniteLegale} />
               <br />
             </>
           ) : isServicePublic(uniteLegale) ? null : (

--- a/components/title-section/index.tsx
+++ b/components/title-section/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AssociationAdressAlert from '#components-ui/alerts/association-adress';
 import MultipleSirenAlert from '#components-ui/alerts/multiple-siren';
 import NonDiffusibleAlert from '#components-ui/alerts/non-diffusible';
 import ProtectedData from '#components-ui/alerts/protected-data';
@@ -10,15 +9,15 @@ import SocialMedia from '#components-ui/social-media';
 import { Tag } from '#components-ui/tag';
 import UniteLegaleBadge from '#components/unite-legale-badge';
 import { UniteLegaleDescription } from '#components/unite-legale-description';
-import { isAssociation, IUniteLegale } from '#models/index';
+import { UniteLegaleEtablissementCountDescription } from '#components/unite-legale-description/etablissement-count-description';
+import { IUniteLegale } from '#models/index';
 import {
   estDiffusible,
   estNonDiffusible,
   getNomComplet,
 } from '#models/statut-diffusion';
 import { formatIntFr } from '#utils/helpers';
-import { isAgent, ISession } from '#utils/session';
-import { UniteLegaleEtablissementCountDescription } from '#components/unite-legale-description/etablissement-count-description';
+import { ISession, isAgent } from '#utils/session';
 import { FICHE, Tabs } from './tabs';
 
 type IProps = {
@@ -68,9 +67,6 @@ const Title: React.FC<IProps> = ({
         </>
       )}
       <MultipleSirenAlert uniteLegale={uniteLegale} />
-      {isAssociation(uniteLegale) && (
-        <AssociationAdressAlert uniteLegale={uniteLegale} session={session} />
-      )}
       <h1>
         <a href={`/entreprise/${uniteLegale.chemin}`}>
           {getNomComplet(uniteLegale, session)}

--- a/components/title-section/tabs.tsx
+++ b/components/title-section/tabs.tsx
@@ -3,11 +3,9 @@ import {
   checkHasLabelsAndCertificates,
   checkHasQuality,
 } from '#components/labels-and-certificates-badges-section';
-import { isAPINotResponding } from '#models/api-not-responding';
 import constants from '#models/constants';
 import {
   IUniteLegale,
-  isAssociation,
   isCollectiviteTerritoriale,
   isServicePublic,
 } from '#models/index';
@@ -38,14 +36,7 @@ export const Tabs: React.FC<{
     // hide for public services
     !isServicePublic(uniteLegale) &&
     // hide for EI
-    !uniteLegale.complements.estEntrepreneurIndividuel &&
-    // hide for asso without bilans
-    !(
-      isAssociation(uniteLegale) &&
-      (!uniteLegale.association.data ||
-        isAPINotResponding(uniteLegale.association.data) ||
-        (uniteLegale.association.data?.bilans || []).length === 0)
-    );
+    !uniteLegale.complements.estEntrepreneurIndividuel;
 
   const tabs = [
     {

--- a/hooks/fetch/comptes-association.ts
+++ b/hooks/fetch/comptes-association.ts
@@ -6,9 +6,9 @@ import { IdRna } from '#utils/helpers';
 import logErrorInSentry from '#utils/sentry';
 import { useFetchData } from './use-fetch-data';
 
-export const useFetchComptesAssociation = (association: IAssociation) => {
-  const idRna = association.association.idAssociation as IdRna;
-  const siren = association.siren;
+export const useFetchComptesAssociation = (uniteLegale: IAssociation) => {
+  const idRna = uniteLegale.association.idAssociation as IdRna;
+  const siren = uniteLegale.siren;
   return useFetchData(
     {
       fetchData: () => clientDCA(siren, idRna as IdRna),
@@ -29,6 +29,6 @@ export const useFetchComptesAssociation = (association: IAssociation) => {
         logErrorInSentry(exception);
       },
     },
-    [association]
+    [uniteLegale]
   );
 };

--- a/hooks/fetch/joafe.ts
+++ b/hooks/fetch/joafe.ts
@@ -6,8 +6,8 @@ import { IdRna } from '#utils/helpers';
 import logErrorInSentry from '#utils/sentry';
 import { useFetchData } from './use-fetch-data';
 
-export const useFetchJOAFE = (association: IAssociation) => {
-  const idRna = association.association.idAssociation as IdRna;
+export const useFetchJOAFE = (uniteLegale: IAssociation) => {
+  const idRna = uniteLegale.association.idAssociation as IdRna;
 
   return useFetchData(
     {
@@ -23,7 +23,7 @@ export const useFetchJOAFE = (association: IAssociation) => {
           cause: e,
           context: {
             idRna,
-            siren: association.siren,
+            siren: uniteLegale.siren,
           },
         });
         logErrorInSentry(exception);

--- a/models/index.ts
+++ b/models/index.ts
@@ -7,7 +7,6 @@ import { IETATADMINSTRATIF } from '#models/etat-administratif';
 import { IEtatCivil } from '#models/immatriculation';
 import { IdRna, Siren, Siret } from '#utils/helpers';
 import { EAdministration } from './administrations/EAdministration';
-import { IAPINotRespondingError } from './api-not-responding';
 import { IConventionsCollectives } from './conventions-collectives-list';
 import {
   Exception,
@@ -105,7 +104,6 @@ export interface IUniteLegale extends IEtablissementsList {
   complements: IUniteLegaleComplements;
   association: {
     idAssociation: IdRna | string | null;
-    data: IAPINotRespondingError | IDataAssociation | null;
   };
   colter: {
     codeColter: string | null;
@@ -142,7 +140,6 @@ export const createDefaultUniteLegale = (siren: Siren): IUniteLegale => {
     complements: createDefaultUniteLegaleComplements(),
     association: {
       idAssociation: null,
-      data: null,
     },
     colter: {
       codeColter: null,
@@ -190,7 +187,6 @@ export const createDefaultUniteLegaleComplements = () => {
 export interface IAssociation extends Omit<IUniteLegale, 'association'> {
   association: {
     idAssociation: IdRna | string;
-    data: IUniteLegale['association']['data'];
   };
 }
 

--- a/models/unite-legale.ts
+++ b/models/unite-legale.ts
@@ -10,7 +10,6 @@ import {
   clientAllEtablissementsInsee,
   clientSiegeInsee,
 } from '#clients/sirene-insee/siret';
-import { getAssociation } from '#models/association';
 import { createEtablissementsList } from '#models/etablissements-list';
 import { IETATADMINSTRATIF, estActif } from '#models/etat-administratif';
 import {
@@ -20,12 +19,7 @@ import {
 } from '#utils/helpers';
 import { isProtectedSiren } from '#utils/helpers/is-protected-siren-or-siret';
 import { logFatalErrorInSentry, logWarningInSentry } from '#utils/sentry';
-import {
-  IUniteLegale,
-  SirenNotFoundError,
-  createDefaultUniteLegale,
-  isAssociation,
-} from '.';
+import { IUniteLegale, SirenNotFoundError, createDefaultUniteLegale } from '.';
 import { EAdministration } from './administrations/EAdministration';
 import {
   APINotRespondingFactory,
@@ -74,11 +68,6 @@ class UniteLegaleBuilder {
 
     // determine TVA
     uniteLegale.tva = getTvaUniteLegale(uniteLegale);
-
-    // no need to call API association for bots
-    if (!this._isBot && isAssociation(uniteLegale)) {
-      uniteLegale.association.data = await getAssociation(uniteLegale);
-    }
 
     if (isProtectedSiren(uniteLegale.siren)) {
       uniteLegale.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;

--- a/pages/annonces/[slug].tsx
+++ b/pages/annonces/[slug].tsx
@@ -43,8 +43,8 @@ const Annonces: NextPageWithLayout<IProps> = ({
         <AnnoncesBodacc uniteLegale={uniteLegale} />
         {isAssociation(uniteLegale) && (
           <>
-            <AnnoncesAssociationSection association={uniteLegale} />
-            <ComptesAssociationSection association={uniteLegale} />
+            <AnnoncesAssociationSection uniteLegale={uniteLegale} />
+            <ComptesAssociationSection uniteLegale={uniteLegale} />
           </>
         )}
       </div>

--- a/pages/donnees-financieres/[slug].tsx
+++ b/pages/donnees-financieres/[slug].tsx
@@ -1,7 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { HorizontalSeparator } from '#components-ui/horizontal-separator';
 import DocumentBilansSection from '#components/espace-agent-components/documents/bilans';
-import { FinancesAssociationSection } from '#components/finances-section/association';
 import { FinancesSocieteSection } from '#components/finances-section/societe';
 import Meta from '#components/meta';
 import Title from '#components/title-section';
@@ -41,9 +40,8 @@ const FinancePage: NextPageWithLayout<IProps> = ({
           uniteLegale={uniteLegale}
           session={session}
         />
-        {isAssociation(uniteLegale) ? (
-          <FinancesAssociationSection association={uniteLegale} />
-        ) : isServicePublic(uniteLegale) ? null : (
+        {/* We use to have finances for association but data disappeared from open data API. Code still exists in <FinancesAssociationSection /> */}
+        {isAssociation(uniteLegale) || isServicePublic(uniteLegale) ? null : (
           <>
             <FinancesSocieteSection uniteLegale={uniteLegale} />
             {isAgent(session) && (

--- a/pages/entreprise/[slug].tsx
+++ b/pages/entreprise/[slug].tsx
@@ -13,7 +13,10 @@ import Title from '#components/title-section';
 import { FICHE } from '#components/title-section/tabs';
 import UniteLegaleSection from '#components/unite-legale-section';
 import UsefulShortcuts from '#components/useful-shortcuts';
+import { IAPINotRespondingError } from '#models/api-not-responding';
+import { getAssociation } from '#models/association';
 import {
+  IDataAssociation,
   IUniteLegale,
   isAssociation,
   isCollectiviteTerritoriale,
@@ -37,11 +40,13 @@ import { NextPageWithLayout } from 'pages/_app';
 
 interface IProps extends IPropsWithMetadata {
   uniteLegale: IUniteLegale;
+  association: IDataAssociation | IAPINotRespondingError | null;
   redirected: boolean;
 }
 
 const UniteLegalePage: NextPageWithLayout<IProps> = ({
   uniteLegale,
+  association,
   redirected,
 }) => {
   const session = useSession();
@@ -81,7 +86,10 @@ const UniteLegalePage: NextPageWithLayout<IProps> = ({
               <EspaceAgentSummarySection uniteLegale={uniteLegale} />
             )}
             {isAssociation(uniteLegale) && (
-              <AssociationSection uniteLegale={uniteLegale} />
+              <AssociationSection
+                uniteLegale={uniteLegale}
+                association={association}
+              />
             )}
             {isCollectiviteTerritoriale(uniteLegale) && (
               <CollectiviteTerritorialeSection uniteLegale={uniteLegale} />
@@ -127,9 +135,15 @@ export const getServerSideProps: GetServerSideProps = postServerSideProps(
       isBot,
     });
 
+    const shouldFetchAssociation = !isBot && isAssociation(uniteLegale);
+    const association = shouldFetchAssociation
+      ? await getAssociation(uniteLegale)
+      : null;
+
     return {
       props: {
         uniteLegale,
+        association,
         redirected: isRedirected,
       },
     };


### PR DESCRIPTION
close #728 

Fllowing @johangirod new sentry setup I noticed a lot of 429 from RNA get trigger on etablissement page where data from RNA is not used !

I propose to uncouple RNA from uniteLegale construction and make it a dedicated data source.

I also cleaned the financeAssoSection, not used since RNA remove association finances from its payload and move the adress warning into the RNA section as it is more relevant there.

This should significantly reduce 429