### PR TITLE
fix: fetch resource exception is not defined

### DIFF
--- a/frontend/src/fetch-tva.js
+++ b/frontend/src/fetch-tva.js
@@ -33,12 +33,7 @@ import { extractSirenSlugFromUrl, formatIntFr } from './utils';
         // We dont log errors, as they are already logged in the backend
         tvaContainer.setError();
         if (e instanceof TypeError) {
-          throw new new FetchRessourceException({
-            ressource: 'VerifyTVA',
-            cause: e,
-            context: { siren },
-            administration: EAdministration.VIES,
-          })();
+          throw e;
         }
       });
   }

--- a/frontend/src/fetch-tva.js
+++ b/frontend/src/fetch-tva.js
@@ -33,7 +33,7 @@ import { extractSirenSlugFromUrl, formatIntFr } from './utils';
         // We dont log errors, as they are already logged in the backend
         tvaContainer.setError();
         if (e instanceof TypeError) {
-          throw e;
+          throw new Error("Client error while fetching TVA", {cause : e});
         }
       });
   }


### PR DESCRIPTION
Unsure what to do here when `FetchRessourceException is not defined`

https://errors.data.gouv.fr/organizations/sentry/issues/131620/?project=16&query=is%3Aunresolved&referrer=issue-stream

I think it is dangerous to share code between vite and react. I would advise using a custom exception here. 

I would be more confortable if you handle it from here @johangirod 