### PR TITLE
feat: hide bodacc for protected siren

### DIFF
--- a/components/etablissement-liste-section/index.tsx
+++ b/components/etablissement-liste-section/index.tsx
@@ -146,7 +146,7 @@ const EtablissementListeSection: React.FC<{
           </>
         ) : (
           <>
-            {nombreEtablissementsOuverts > 0 && (
+            {uniteLegale.etablissements.open.length > 0 && (
               <>
                 <EtablissementTable
                   label="actif"

--- a/components/non-diffusible/index.tsx
+++ b/components/non-diffusible/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ButtonLink from '#components-ui/button';
 import { INSEE } from '#components/administrations';
 import { Section } from '#components/section';
@@ -34,7 +33,7 @@ export const NonDiffusibleSection = () => (
   </Section>
 );
 
-export const DirigeantsNonDiffusibleSection = () => (
+export const DonneesPriveesSection = () => (
   <Section title="Données privées">
     <p>
       Les dirigeants de cette entreprise ont demandé à ce que ces informations

--- a/models/unite-legale.ts
+++ b/models/unite-legale.ts
@@ -71,6 +71,13 @@ class UniteLegaleBuilder {
 
     if (isProtectedSiren(uniteLegale.siren)) {
       uniteLegale.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+      uniteLegale.siege.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+
+      const allProtected = uniteLegale.etablissements.all.map((e) => {
+        e.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+        return e;
+      });
+      uniteLegale.etablissements = createEtablissementsList(allProtected);
     }
 
     // en sommeil

--- a/pages/annonces/[slug].tsx
+++ b/pages/annonces/[slug].tsx
@@ -3,9 +3,11 @@ import AnnoncesAssociationSection from '#components/annonces-section/annonces-as
 import AnnoncesBodacc from '#components/annonces-section/bodacc';
 import { ComptesAssociationSection } from '#components/annonces-section/comptes-association';
 import Meta from '#components/meta';
+import { DonneesPriveesSection } from '#components/non-diffusible';
 import Title from '#components/title-section';
 import { FICHE } from '#components/title-section/tabs';
 import { IUniteLegale, isAssociation } from '#models/index';
+import { estDiffusible } from '#models/statut-diffusion';
 import { getUniteLegaleFromSlug } from '#models/unite-legale';
 import { getCompanyPageDescription, getCompanyPageTitle } from '#utils/helpers';
 import extractParamsFromContext from '#utils/server-side-props-helper/extract-params-from-context';
@@ -13,6 +15,7 @@ import {
   IPropsWithMetadata,
   postServerSideProps,
 } from '#utils/server-side-props-helper/post-server-side-props';
+import { isAgent } from '#utils/session';
 import { NextPageWithLayout } from 'pages/_app';
 
 interface IProps extends IPropsWithMetadata {
@@ -40,7 +43,11 @@ const Annonces: NextPageWithLayout<IProps> = ({
           uniteLegale={uniteLegale}
           session={session}
         />
-        <AnnoncesBodacc uniteLegale={uniteLegale} />
+        {estDiffusible(uniteLegale) || isAgent(session) ? (
+          <AnnoncesBodacc uniteLegale={uniteLegale} />
+        ) : (
+          <DonneesPriveesSection />
+        )}
         {isAssociation(uniteLegale) && (
           <>
             <AnnoncesAssociationSection uniteLegale={uniteLegale} />

--- a/pages/dirigeants/[slug].tsx
+++ b/pages/dirigeants/[slug].tsx
@@ -5,7 +5,7 @@ import DirigeantsEntrepriseIndividuelleSection from '#components/dirigeants-sect
 import DirigeantsSection from '#components/dirigeants-section/rne-dirigeants';
 import DirigeantSummary from '#components/dirigeants-section/summary';
 import Meta from '#components/meta';
-import { DirigeantsNonDiffusibleSection } from '#components/non-diffusible';
+import { DonneesPriveesSection } from '#components/non-diffusible';
 import Title from '#components/title-section';
 import { FICHE } from '#components/title-section/tabs';
 import { IUniteLegale } from '#models/index';
@@ -75,7 +75,7 @@ const DirigeantsPage: NextPageWithLayout<IProps> = ({
               />
             </>
           ) : (
-            <DirigeantsNonDiffusibleSection />
+            <DonneesPriveesSection />
           )}
         </>
       </div>


### PR DESCRIPTION
Follow up of two support tickets : 
- protected siren and non-diffusible now also apply to BODACC (also discussed with the SPM's DPD)
- protected siren apply to its etablissements (that was more of a bug)