### PR TITLE
feat: improve elus section

### DIFF
--- a/components-ui/alerts/association-adress.tsx
+++ b/components-ui/alerts/association-adress.tsx
@@ -1,4 +1,5 @@
 import { INSEE, MI } from '#components/administrations';
+import NonRenseigne from '#components/non-renseigne';
 import {
   IAPINotRespondingError,
   isAPINotResponding,
@@ -28,7 +29,7 @@ const AssociationAdressAlert: React.FC<{
           <INSEE /> :
           <ul>
             <li>
-              <MI /> : {associationAdresse || 'Non renseignée'}
+              <MI /> : {associationAdresse || <NonRenseigne />}
             </li>
             <li>
               <INSEE /> : {getAdresseUniteLegale(uniteLegale, null)}

--- a/components-ui/badge/frequent.tsx
+++ b/components-ui/badge/frequent.tsx
@@ -106,7 +106,7 @@ export const OpenClosedTag: React.FC<
       icon={isVerified ? 'open' : 'closed'}
       label={label}
       backgroundColor="#ddd"
-      fontColor="#555"
+      fontColor="var(--text-default-grey)"
     />
   </div>
 );

--- a/components-ui/badge/index.tsx
+++ b/components-ui/badge/index.tsx
@@ -78,6 +78,7 @@ export function Badge({
         }
         a.badge-wrapper .badge-label {
           text-decoration: underline;
+          color: var(--text-default-grey);
         }
         a.badge-wrapper:hover {
           filter: brightness(0.95);
@@ -101,7 +102,6 @@ export function Badge({
           border-top-right-radius: 50px;
           border-bottom-right-radius: 50px;
           background-color: #eee;
-          color: #555;
           font-weight: bold;
           padding: ${small ? '0 8px 0 6px' : '2px 10px 2px 8px'};
         }

--- a/components-ui/filter-menu/filter-menu.tsx
+++ b/components-ui/filter-menu/filter-menu.tsx
@@ -1,11 +1,11 @@
-import { PropsWithChildren, ReactElement, useState } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import ButtonLink from '#components-ui/button';
 import { Icon } from '#components-ui/icon/wrapper';
 import constants from '#models/constants';
 import {
-  buildSearchQuery,
   IParams,
   ISearchFilter,
+  buildSearchQuery,
 } from '#models/search-filter-params';
 import { useOutsideClick } from 'hooks';
 import ActiveFilterLabel from './active-filter-label';
@@ -100,7 +100,7 @@ export const FilterMenu: React.FC<PropsWithChildren<FilterMenuProps>> = ({
           }
 
           span.search-filter-label {
-            color: #555;
+            color: var(--text-default-grey);
             user-select: none;
             display: flex;
             align-items: center;

--- a/components/banner/info-banner.tsx
+++ b/components/banner/info-banner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PrintNever } from '#components-ui/print-visibility';
-import { INPI, INSEE } from '#components/administrations';
+import { INSEE } from '#components/administrations';
+import NonRenseigne from '#components/non-renseigne';
 import constants from '#models/constants';
 
 export const InfoBanner: React.FC<{}> = () => (
@@ -18,7 +19,7 @@ export const InfoBanner: React.FC<{}> = () => (
           <li>
             Sur la page d’un établissement ou d’un siège social, le nombre de
             salariés, la date de fermeture et la date de dernière mise à jour
-            sont <i>Non renseigné</i>
+            sont <NonRenseigne />
           </li>
           <li>
             Si une entreprise a plus de 100 établissements, la liste de ses

--- a/components/conventions-collectives-section/index.tsx
+++ b/components/conventions-collectives-section/index.tsx
@@ -4,6 +4,7 @@ import ButtonLink from '#components-ui/button';
 import FAQLink from '#components-ui/faq-link';
 import { Tag } from '#components-ui/tag';
 import { MTPEI } from '#components/administrations';
+import NonRenseigne from '#components/non-renseigne';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
 import { EAdministration } from '#models/administrations/EAdministration';
@@ -71,7 +72,7 @@ const ConventionsCollectivesSection: React.FC<{
                         </>
                       )}
                       <span className="font-small">
-                        {title || <i>Non renseigné</i>}
+                        {title || <NonRenseigne />}
                       </span>
                     </>,
                     <ul>
@@ -85,7 +86,7 @@ const ConventionsCollectivesSection: React.FC<{
                     </ul>,
                     <>
                       {idcc === '9999' ? (
-                        <i>Non renseigné</i>
+                        <NonRenseigne />
                       ) : (
                         <ButtonLink
                           target="_blank"

--- a/components/dirigeants-section/elus-section.tsx
+++ b/components/dirigeants-section/elus-section.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import NonRenseigne from '#components/non-renseigne';
 import { EAdministration } from '#models/administrations/EAdministration';
 import { IEtatCivil } from '#models/immatriculation';
 import { isCollectiviteTerritoriale, IUniteLegale } from '#models/index';
-import { formatDatePartial } from '#utils/helpers';
+import { capitalize, formatDatePartial } from '#utils/helpers';
 import { Section } from '../section';
 import { FullTable } from '../table/full';
 
@@ -26,10 +27,12 @@ const ElusSection: React.FC<{ uniteLegale: IUniteLegale }> = ({
     }${(elu.nom || '').toUpperCase()}`;
 
     const infos = [
-      elu.role ?? <span style={{ color: '#555' }}>Non renseigné</span>,
+      elu.role ?? <NonRenseigne />,
       <>{nomComplet}</>,
-      <span style={{ textTransform: 'capitalize' }}>
-        {formatDatePartial(elu.dateNaissancePartial)}
+      <span>
+        {capitalize(formatDatePartial(elu.dateNaissancePartial) ?? '') || (
+          <NonRenseigne />
+        )}
       </span>,
     ];
 
@@ -63,7 +66,7 @@ const ElusSection: React.FC<{ uniteLegale: IUniteLegale }> = ({
           </p>
         )}
       </Section>
-      <style global jsx>{`
+      <style jsx>{`
         table > tbody > tr > td {
           min-width: 30%;
         }

--- a/components/dirigeants-section/elus-section.tsx
+++ b/components/dirigeants-section/elus-section.tsx
@@ -26,10 +26,11 @@ const ElusSection: React.FC<{ uniteLegale: IUniteLegale }> = ({
     }${(elu.nom || '').toUpperCase()}`;
 
     const infos = [
-      elu.role,
-      <>
-        {nomComplet}, né(e) en {formatDatePartial(elu.dateNaissancePartial)}
-      </>,
+      elu.role ?? <span style={{ color: '#555' }}>Non renseigné</span>,
+      <>{nomComplet}</>,
+      <span style={{ textTransform: 'capitalize' }}>
+        {formatDatePartial(elu.dateNaissancePartial)}
+      </span>,
     ];
 
     return infos;
@@ -51,10 +52,8 @@ const ElusSection: React.FC<{ uniteLegale: IUniteLegale }> = ({
               {plural} au Répertoire National des Élus&nbsp;:
             </p>
             <FullTable
-              head={['Role', 'Details']}
-              body={elus
-                .sort((a) => (!a.role ? 1 : -1))
-                .map((elu) => formatElus(elu))}
+              head={['Role', 'Élu(e)', 'Date de naissance']}
+              body={elus.sort(sortByRole).map((elu) => formatElus(elu))}
             />
           </>
         ) : (
@@ -65,11 +64,38 @@ const ElusSection: React.FC<{ uniteLegale: IUniteLegale }> = ({
         )}
       </Section>
       <style global jsx>{`
-        table > tbody > tr > td:first-of-type {
-          width: 30%;
+        table > tbody > tr > td {
+          min-width: 30%;
         }
       `}</style>
     </>
   );
 };
 export default ElusSection;
+
+type IElu = {
+  role?: string;
+};
+function sortByRole(a: IElu, b: IElu): -1 | 1 | 0 {
+  const roleA = a.role;
+  const roleB = b.role;
+  if (roleA === roleB) {
+    return 0;
+  }
+  if (roleA === 'Maire') {
+    return -1;
+  }
+  if (roleB === 'Maire') {
+    return 1;
+  }
+  if (roleA == null) {
+    return 1;
+  }
+  if (roleB == null) {
+    return -1;
+  }
+  if (roleA.match(/^[\d]+/) && roleB.match(/^[\d]+/)) {
+    return parseInt(roleA, 10) < parseInt(roleB, 10) ? -1 : 1;
+  }
+  return roleA < roleB ? -1 : 1;
+}

--- a/components/etablissement-liste-section/index.tsx
+++ b/components/etablissement-liste-section/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import IsActiveTag from '#components-ui/is-active-tag';
 import { Tag } from '#components-ui/tag';
+import NonRenseigne from '#components/non-renseigne';
 import PageCounter from '#components/search-results/results-pagination';
 import { Section } from '#components/section';
 import { FullTable } from '#components/table/full';
@@ -47,14 +48,14 @@ const EtablissementTable: React.FC<{
           </a>,
           <>
             {estNonDiffusible(etablissement) ? (
-              <i>Non renseigné</i>
+              <NonRenseigne />
             ) : (
               etablissement.libelleActivitePrincipale
             )}
           </>,
           <>
             {estNonDiffusible(etablissement) ? (
-              <i>Non renseigné</i>
+              <NonRenseigne />
             ) : (
               <>
                 <span style={{ fontVariant: 'all-small-caps' }}>

--- a/components/labels-and-certificates/bio/index.tsx
+++ b/components/labels-and-certificates/bio/index.tsx
@@ -4,6 +4,7 @@ import ButtonLink from '#components-ui/button';
 import FAQLink from '#components-ui/faq-link';
 import { Icon } from '#components-ui/icon/wrapper';
 import { Tag } from '#components-ui/tag';
+import NonRenseigne from '#components/non-renseigne';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
 import { EAdministration } from '#models/administrations/EAdministration';
@@ -154,7 +155,7 @@ const getCertificationDate = (certificat: IBioCertification) => {
       </>
     ),
   };
-  return status ? mapping[status] : 'Non renseigné';
+  return status ? mapping[status] : <NonRenseigne />;
 };
 
 const FAQBio = ({ label = 'certification Bio' }) => (

--- a/components/labels-and-certificates/entrepreneur-spectacles/index.tsx
+++ b/components/labels-and-certificates/entrepreneur-spectacles/index.tsx
@@ -4,6 +4,7 @@ import { Icon } from '#components-ui/icon/wrapper';
 import InformationTooltip from '#components-ui/information-tooltip';
 import { Tag } from '#components-ui/tag';
 import { MC } from '#components/administrations';
+import NonRenseigne from '#components/non-renseigne';
 import { DataSection } from '#components/section/data-section';
 import { FullTable } from '#components/table/full';
 import { EAdministration } from '#models/administrations/EAdministration';
@@ -135,7 +136,7 @@ const formatLicence = (categorie: number, nomLieu = '') => {
     case 3:
       return <b>Diffuseurs de spectacles</b>;
     default:
-      return <i>Non renseigné</i>;
+      return <NonRenseigne />;
   }
 };
 

--- a/components/non-renseigne/index.tsx
+++ b/components/non-renseigne/index.tsx
@@ -1,0 +1,8 @@
+export default function NonRenseigne() {
+  return (
+    <>
+      <em>Non renseigné</em>
+      <style jsx>{``}</style>
+    </>
+  );
+}

--- a/components/search-results/results-counter.tsx
+++ b/components/search-results/results-counter.tsx
@@ -39,7 +39,7 @@ const ResultsCounter: React.FC<{
       <style jsx>{`
         .results-counter {
           margin-top: 20px;
-          color: #555;
+          color: var(--text-default-grey);
         }
       `}</style>
     </>

--- a/components/search-results/results-list.tsx
+++ b/components/search-results/results-list.tsx
@@ -45,8 +45,8 @@ const DirigeantsOrElusList: React.FC<{
       </Icon>
       <style jsx>{`
         .dirigeants-or-elus {
+          color: var(--text-default-grey);
           font-size: 0.9rem;
-          color: #555;
           margin: 8px auto;
         }
       `}</style>

--- a/components/table/simple.tsx
+++ b/components/table/simple.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import NonRenseigne from '#components/non-renseigne';
 import constants from '#models/constants';
 import { InternalError } from '#models/index';
 import { logWarningInSentry } from '#utils/sentry';
@@ -25,11 +26,11 @@ const Cell: React.FC<PropsWithChildren<{ label?: string }>> = ({
     <td>
       {isCopyEnabled ? (
         <CopyPaste shouldTrim={shouldTrim(label)}>
-          {children || <i>Non renseigné</i>}
+          {children || <NonRenseigne />}
         </CopyPaste>
       ) : (
         <div>
-          <span>{children || <i>Non renseigné</i>}</span>
+          <span>{children || <NonRenseigne />}</span>
         </div>
       )}
       <style jsx>{`

--- a/frontend/style/globals.css
+++ b/frontend/style/globals.css
@@ -158,3 +158,8 @@ h4 {
 *:hover > .anchor-link {
   opacity: 1;
 }
+
+/* Prevent the first column of table to be too small */
+table > tbody > tr > td:first-of-type {
+  min-width: 30%;
+}


### PR DESCRIPTION
- sort by role (maire first, then by adjoint number, then by name)
- display date of birth separately
- add « non renseigné » when role is not provided

![image](https://github.com/etalab/annuaire-entreprises-site/assets/1775934/f9000919-0f54-49f0-b57e-2602b96cd849)

Considering doing the same for `dirigeant` section, what do you think?

closes #549