### PR TITLE
fix: failed to fetch exception erasing the status is breaking section polymorphism

### DIFF
--- a/components/espace-agent-components/documents/actes.tsx
+++ b/components/espace-agent-components/documents/actes.tsx
@@ -27,7 +27,7 @@ const DocumentActesSection: React.FC<{
             {(isAssociation(uniteLegale) || isServicePublic(uniteLegale)) && (
               <>
                 <Warning full>
-                  Les asociations et les services publics ne sont pas
+                  Les associations et les services publics ne sont pas
                   immatriculés au RNE.
                 </Warning>
                 <br />

--- a/components/espace-agent-components/documents/bilans.tsx
+++ b/components/espace-agent-components/documents/bilans.tsx
@@ -30,7 +30,7 @@ const DocumentBilansSection: React.FC<{
             {(isAssociation(uniteLegale) || isServicePublic(uniteLegale)) && (
               <>
                 <Warning full>
-                  Les asociations et les services publics ne sont pas
+                  Les associations et les services publics ne sont pas
                   immatriculés au RNE.
                 </Warning>
                 <br />

--- a/pages/donnees-financieres/[slug].tsx
+++ b/pages/donnees-financieres/[slug].tsx
@@ -1,6 +1,5 @@
 import { GetServerSideProps } from 'next';
 import { HorizontalSeparator } from '#components-ui/horizontal-separator';
-import DocumentBilansSection from '#components/espace-agent-components/documents/bilans';
 import { FinancesSocieteSection } from '#components/finances-section/societe';
 import Meta from '#components/meta';
 import Title from '#components/title-section';
@@ -47,7 +46,6 @@ const FinancePage: NextPageWithLayout<IProps> = ({
             {isAgent(session) && (
               <>
                 <HorizontalSeparator />
-                <DocumentBilansSection uniteLegale={uniteLegale} />
               </>
             )}
           </>

--- a/pages/donnees-financieres/[slug].tsx
+++ b/pages/donnees-financieres/[slug].tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { HorizontalSeparator } from '#components-ui/horizontal-separator';
+import DocumentBilansSection from '#components/espace-agent-components/documents/bilans';
 import { FinancesSocieteSection } from '#components/finances-section/societe';
 import Meta from '#components/meta';
 import Title from '#components/title-section';
@@ -46,6 +47,7 @@ const FinancePage: NextPageWithLayout<IProps> = ({
             {isAgent(session) && (
               <>
                 <HorizontalSeparator />
+                <DocumentBilansSection uniteLegale={uniteLegale} />
               </>
             )}
           </>

--- a/utils/network/frontend/index.ts
+++ b/utils/network/frontend/index.ts
@@ -66,7 +66,7 @@ export async function httpFrontClient<T>(config: IDefaultRequestConfig) {
     }
 
     return data as T;
-  } catch (e) {
+  } catch (e: any) {
     const errorArgs = {
       context: { page: config.url, details: `method: ${config.method}` },
       cause: e,
@@ -77,7 +77,7 @@ export async function httpFrontClient<T>(config: IDefaultRequestConfig) {
       // We don't want this error to bubble though the app
       throw new RequestAbortedDuringUnloadException(errorArgs);
     }
-    throw new FailToFetchError(errorArgs);
+    throw new FailToFetchError(errorArgs, e.status);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -101,7 +101,10 @@ export class RequestAbortedDuringUnloadException extends Exception {
 }
 
 export class FailToFetchError extends Exception {
-  constructor(args: { context: IExceptionContext; cause: any }) {
+  constructor(
+    args: { context: IExceptionContext; cause: any },
+    public status = 500
+  ) {
     super({
       name: 'FailToFetchError',
       message: 'Error while trying to fetch ressource from client',


### PR DESCRIPTION
Pretty big regression here : 
Section would rely on status to display `NotFoundInfo` and FailToFetchError would hide it compared to previous HttpErrors

I think this need a further investigation to ensure that no other part of the app using similar logic could be impacted  @johangirod 

 