### PR TITLE
fix: missing default export breaks the actes routes

### DIFF
--- a/pages/api/data-fetching/espace-agent/documents/[slug].tsx
+++ b/pages/api/data-fetching/espace-agent/documents/[slug].tsx
@@ -7,7 +7,7 @@ import logErrorInSentry from '#utils/sentry';
 import { isAgent } from '#utils/session';
 import withSession from '#utils/session/with-session';
 
-withSession(async function actes(req, res) {
+export default withSession(async function actes(req, res) {
   const {
     query: { slug },
     session,

--- a/pages/api/data-fetching/espace-agent/documents/download/[slug].tsx
+++ b/pages/api/data-fetching/espace-agent/documents/download/[slug].tsx
@@ -9,7 +9,7 @@ import logErrorInSentry from '#utils/sentry';
 import { isAgent } from '#utils/session';
 import withSession from '#utils/session/with-session';
 
-withSession(async function download(req, res) {
+export default withSession(async function download(req, res) {
   const {
     query: { slug, type },
     session,

--- a/pages/api/data-fetching/rne/[slug].ts
+++ b/pages/api/data-fetching/rne/[slug].ts
@@ -39,8 +39,4 @@ const getRNE = async (
   }
 };
 
-class FetchRNEImmatriculationException extends Error {
-  name = 'FetchRNEImmatriculationException';
-}
-
 export default withAPM(withAntiBot(getRNE));


### PR DESCRIPTION
@johangirod I think this was introduced in the last bump package PR