### PR TITLE
test: add basic data-fetching routes tests

### DIFF
--- a/components-ui/button-agent-connect/index.tsx
+++ b/components-ui/button-agent-connect/index.tsx
@@ -5,12 +5,10 @@ const ButtonAgentConnect: React.FC<{}> = () => {
   const pathFrom = usePathFromRouter();
   return (
     <div>
-      <form
-        action={`/api/auth/agent-connect/login${
-          pathFrom ? `?pathFrom=${pathFrom}` : ''
-        }`}
-        method="get"
-      >
+      <form action="/api/auth/agent-connect/login" method="get">
+        {pathFrom && (
+          <input readOnly hidden aria-hidden name="pathFrom" value={pathFrom} />
+        )}
         <button className="agentconnect-button"></button>
       </form>
       <p>

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -85,10 +85,7 @@ export const Header: React.FC<IProps> = ({
                       {isLoggedIn(session) ? (
                         <ul className="fr-links-group">
                           <li>
-                            <a
-                              className="fr-link menu-logout"
-                              href={`/api/auth/agent-connect/logout?pathFrom=${pathFrom}`}
-                            >
+                            <div className="fr-link menu-logout">
                               <div>
                                 <Icon slug="user">
                                   {session?.user?.fullName ||
@@ -106,8 +103,12 @@ export const Header: React.FC<IProps> = ({
                                   )
                                 </Icon>
                               </div>
-                              <div>Se déconnecter</div>
-                            </a>
+                              <a
+                                href={`/api/auth/agent-connect/logout?pathFrom=${pathFrom}`}
+                              >
+                                <div>Se déconnecter</div>
+                              </a>
+                            </div>
                           </li>
                         </ul>
                       ) : null}
@@ -161,10 +162,14 @@ export const Header: React.FC<IProps> = ({
           position: absolute;
         }
 
-        a.menu-logout {
+        div.menu-logout {
           position: relative;
         }
-        a.menu-logout div:last-of-type {
+        div.menu-logout:hover {
+          background-color: #eee;
+          cursor: default;
+        }
+        div.menu-logout > a {
           position: absolute;
           top: 100%;
           left: 0;
@@ -172,13 +177,13 @@ export const Header: React.FC<IProps> = ({
           width: 100%;
           background-color: #fff;
           padding: 5px 15px;
-          box-shadow: 0 10px 20px -10px rgba(0, 0, 0, 0.35);
+          box-shadow: 0 10px 15px -10px rgba(0, 0, 0, 0.5);
         }
-        a.menu-logout div:last-of-type:hover {
-          background-color: #fbfbfb;
+        div.menu-logout > a:hover {
+          background-color: #f8f8f8;
         }
 
-        a.menu-logout:hover div:last-of-type {
+        div.menu-logout:hover > a {
           display: block;
         }
 

--- a/cypress/e2e/data-fetching.cy.js
+++ b/cypress/e2e/data-fetching.cy.js
@@ -1,0 +1,54 @@
+describe('Data fetching routes', () => {
+  it('Agent-only routes are forbidden', () => {
+    cy.request({
+      url: '/api/data-fetching/espace-agent/documents/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(403);
+    });
+
+    cy.request({
+      url: '/api/data-fetching/espace-agent/documents/download/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(403);
+    });
+
+    cy.request({
+      url: '/api/data-fetching/espace-agent/conformite/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(403);
+    });
+
+    cy.visit('/entreprise/danone-552032534');
+
+    cy.request({
+      url: '/api/data-fetching/espace-agent/documents/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(403);
+    });
+    cy.request({
+      url: '/api/data-fetching/espace-agent/conformite/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(403);
+    });
+  });
+  it('Bot-Protected routes are unauthorized', () => {
+    cy.request({
+      url: '/api/data-fetching/verify-tva/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(401);
+    });
+
+    cy.request({
+      url: '/api/data-fetching/rne/552032534',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(401);
+    });
+  });
+});

--- a/cypress/e2e/data-fetching.cy.js
+++ b/cypress/e2e/data-fetching.cy.js
@@ -20,21 +20,6 @@ describe('Data fetching routes', () => {
     }).then((resp) => {
       expect(resp.status).to.eq(403);
     });
-
-    cy.visit('/entreprise/danone-552032534');
-
-    cy.request({
-      url: '/api/data-fetching/espace-agent/documents/552032534',
-      failOnStatusCode: false,
-    }).then((resp) => {
-      expect(resp.status).to.eq(403);
-    });
-    cy.request({
-      url: '/api/data-fetching/espace-agent/conformite/552032534',
-      failOnStatusCode: false,
-    }).then((resp) => {
-      expect(resp.status).to.eq(403);
-    });
   });
   it('Bot-Protected routes are unauthorized', () => {
     cy.request({

--- a/frontend/src/load-bar.js
+++ b/frontend/src/load-bar.js
@@ -33,6 +33,8 @@ const init = () => {
 
   if (loader.style.backgroundColor === 'transparent') {
     loader.style.background = '#000091';
+    loader.style.background =
+      'linear-gradient(90deg, rgba(0,0,145,1), rgb(0, 159, 255))';
   }
 
   document.body.appendChild(loader);

--- a/hooks/use-path-from-router.ts
+++ b/hooks/use-path-from-router.ts
@@ -1,8 +1,12 @@
 import { useRouter } from 'next/router';
 
 export default function usePathFromRouter(): string | null {
-  const router = useRouter();
+  try {
+    const router = useRouter();
 
-  const path = (router?.asPath || '') as string;
-  return path;
+    const path = (router?.asPath || '') as string;
+    return encodeURIComponent(path);
+  } catch {
+    return null;
+  }
 }

--- a/pages/api/auth/agent-connect/callback.ts
+++ b/pages/api/auth/agent-connect/callback.ts
@@ -48,7 +48,7 @@ export default withSession(async function callbackRoute(req, res) {
       session
     );
 
-    const pathFrom = getPathFrom(session);
+    const pathFrom = decodeURIComponent(getPathFrom(session) || '');
 
     if (pathFrom) {
       await cleanPathFrom(session);

--- a/utils/session/with-anti-bot.ts
+++ b/utils/session/with-anti-bot.ts
@@ -30,8 +30,9 @@ export function withAntiBot(handler: NextApiHandler) {
 
       res.status(401);
       res.send('Unauthorized');
+    } else {
+      return handler(req, res);
     }
-    return handler(req, res);
   });
 }
 


### PR DESCRIPTION
Several improvements over current agent login cinematic : 
- add the most basic tests on data-fetching routes
- fix `pathFrom` logic
- fix an anti-bot bug 
- fix an UX issue with the logout menu
- add a gradient on load bar (we have priorities here)