### PR TITLE
fix: formatting when missing dirigeant name in service-public

### DIFF
--- a/clients/open-data-soft/clients/annuaire-service-public/index.ts
+++ b/clients/open-data-soft/clients/annuaire-service-public/index.ts
@@ -33,7 +33,7 @@ type IAffectationRecord = {
   fonction: string;
 };
 
-function firstArrayElement(array: any[], defaultValue: any) {
+function firstArrayElement<T>(array: T[], defaultValue: T): T {
   if (array && array.length && array.length > 0) {
     return array[0] ?? defaultValue;
   }
@@ -121,15 +121,23 @@ function mapToAffectationPersonne(
   if (!affectations || !affectations.length) {
     return null;
   }
-
   return affectations.map((affectation) => ({
-    nom: affectation.personne.prenom + ' ' + affectation.personne.nom,
+    nom: getNom(affectation.personne),
     fonction: affectation.fonction,
     lienTexteAffectation: firstArrayElement(
       affectation.personne.texte_reference,
       null
     ),
   }));
+}
+function getNom(personne: IAffectationRecord['personne']) {
+  if (!personne.prenom && !personne.nom) {
+    return null;
+  }
+  return (
+    personne.prenom +
+    (personne.nom || personne.prenom ? ' ' + personne.nom : '')
+  );
 }
 
 function mapToNom(record: IServicePublicRecord) {
@@ -154,7 +162,10 @@ function mapToAdresse(record: IServicePublicRecord) {
   }
   const adresse =
     adresses.find((a) => a.type_adresse === 'Adresse postale') ??
-    firstArrayElement(adresses, '');
+    firstArrayElement(adresses, null);
+  if (!adresse) {
+    return null;
+  }
   return [
     adresse.complement1,
     adresse.complement2,

--- a/components/dirigeants-section/responsables-service-public.tsx
+++ b/components/dirigeants-section/responsables-service-public.tsx
@@ -64,15 +64,19 @@ export default function ResponsableSection({ servicePublic }: IProps) {
                 head={['Role', 'Nom', 'Nomination']}
                 body={servicePublic.affectationPersonne.map((personne) => [
                   personne.fonction,
-                  personne.nom,
+                  personne.nom ?? <NonRenseigne />,
                   personne.lienTexteAffectation ? (
                     <a
                       href={personne.lienTexteAffectation.valeur}
                       target="_blank"
                       rel="noopener noreferrer"
-                      aria-label={`${personne.lienTexteAffectation.libelle}, nouvelle fenêtre`}
+                      aria-label={`${
+                        personne.lienTexteAffectation.libelle ||
+                        'Voir la nomination'
+                      }, nouvelle fenêtre`}
                     >
-                      {personne.lienTexteAffectation.libelle}
+                      {personne.lienTexteAffectation.libelle ||
+                        'Voir la nomination'}
                     </a>
                   ) : (
                     <NonRenseigne />

--- a/models/service-public/index.ts
+++ b/models/service-public/index.ts
@@ -62,7 +62,7 @@ type ILien = {
   valeur: string;
 };
 type IAffectationPersonne = Array<{
-  nom: string;
+  nom: string | null;
   fonction: string;
   lienTexteAffectation: ILien | null;
 }>;


### PR DESCRIPTION
fix #908 