### PR TITLE
style: generalize #fef6e3 as only light yellow accross site

### DIFF
--- a/components/banner/nps.tsx
+++ b/components/banner/nps.tsx
@@ -33,7 +33,7 @@ export const NPSBanner: React.FC<{}> = () => {
           padding-bottom: 15px;
           font-size: 0.9rem;
           width: 100%;
-          background-color: #fffde6;
+          background-color: #fef6e3;
           font-family: 'Marianne', sans-serif;
           border-bottom: 2px solid ${constants.colors.frBlue};
         }

--- a/components/layouts/layout-connexion.tsx
+++ b/components/layouts/layout-connexion.tsx
@@ -37,7 +37,7 @@ export const LayoutConnexion: React.FC<PropsWithChildren<IProps>> = ({
         }
 
         .img-container:before {
-          background-color: #f5f5fe;
+          background-color: #fef6e3;
           border-radius: 8px;
           position: absolute;
           top: 0;

--- a/components/layouts/layout-connexion.tsx
+++ b/components/layouts/layout-connexion.tsx
@@ -37,7 +37,7 @@ export const LayoutConnexion: React.FC<PropsWithChildren<IProps>> = ({
         }
 
         .img-container:before {
-          background-color: #fef6e3;
+          background-color: #f5f5fe;
           border-radius: 8px;
           position: absolute;
           top: 0;


### PR DESCRIPTION
Use the same yellow as the agent illu for the NPS banner and for connexion pages' background

Not sure about the connexion background

What do you think ?