### PR TITLE
Pasta salad

### DIFF
--- a/clients/api-entreprise/client.ts
+++ b/clients/api-entreprise/client.ts
@@ -1,0 +1,49 @@
+import { HttpUnauthorizedError } from '#clients/exceptions';
+import constants from '#models/constants';
+import { Information } from '#models/exceptions';
+import { httpGet } from '#utils/network';
+import { logInfoInSentry } from '#utils/sentry';
+
+/**
+ * Wrapper client to call API Entreprise
+ *
+ * @param route
+ * @param mapToDomainObject
+ * @param recipientSiret
+ * @returns
+ */
+export default async function clientAPIEntreprise<T, U>(
+  route: string,
+  mapToDomainObject: (e: T) => U,
+  recipientSiret?: string
+) {
+  if (!recipientSiret) {
+    logInfoInSentry(
+      new Information({
+        name: 'NoRecipientSiretForAgent',
+        message: 'Fallback on Dinum siret as recipient',
+      })
+    );
+  }
+
+  if (!process.env.API_ENTREPRISE_URL || !process.env.API_ENTREPRISE_TOKEN) {
+    throw new HttpUnauthorizedError('Missing API Entreprise credentials');
+  }
+
+  // never cache any API Entreprise request
+  const useCache = false;
+
+  const response = await httpGet<T>(route, {
+    headers: {
+      Authorization: `Bearer ${process.env.API_ENTREPRISE_TOKEN}`,
+    },
+    timeout: constants.timeout.XXXL,
+    params: {
+      object: 'espace-agent-public',
+      context: 'annuaire-entreprises',
+      recipient: recipientSiret || '13002526500013',
+    },
+    useCache,
+  });
+  return mapToDomainObject(response);
+}

--- a/clients/api-entreprise/conformite/fiscale.ts
+++ b/clients/api-entreprise/conformite/fiscale.ts
@@ -19,7 +19,7 @@ export type IAPIEntrepriseConformiteFiscale = {
  */
 export const clientApiEntrepriseConformiteFiscale = async (
   siren: Siren,
-  recipientSiret: string
+  recipientSiret?: string
 ) => {
   return await clientAPIEntreprise<
     IAPIEntrepriseConformiteFiscale,

--- a/clients/api-entreprise/conformite/fiscale.ts
+++ b/clients/api-entreprise/conformite/fiscale.ts
@@ -1,8 +1,7 @@
-import { HttpUnauthorizedError } from '#clients/exceptions';
 import routes from '#clients/routes';
-import constants from '#models/constants';
+import { IConformite } from '#models/espace-agent/donnees-restreintes-entreprise';
 import { Siren } from '#utils/helpers';
-import { httpGet } from '#utils/network';
+import clientAPIEntreprise from '../client';
 
 export type IAPIEntrepriseConformiteFiscale = {
   data: {
@@ -18,31 +17,18 @@ export type IAPIEntrepriseConformiteFiscale = {
 /**
  * GET documents from API Entreprise
  */
-export const clientApiEntrepriseConformiteFiscale = async (siren: Siren) => {
-  if (!process.env.API_ENTREPRISE_URL || !process.env.API_ENTREPRISE_TOKEN) {
-    throw new HttpUnauthorizedError('Missing API Entreprise credentials');
-  }
-
-  // never cache any API Entreprise request
-  const useCache = false;
-
-  const response = await httpGet<IAPIEntrepriseConformiteFiscale>(
+export const clientApiEntrepriseConformiteFiscale = async (
+  siren: Siren,
+  recipientSiret: string
+) => {
+  return await clientAPIEntreprise<
+    IAPIEntrepriseConformiteFiscale,
+    IConformite
+  >(
     `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.conformite.fiscale}${siren}/attestation_fiscale`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.API_ENTREPRISE_TOKEN}`,
-      },
-      timeout: constants.timeout.XXXL,
-      params: {
-        object: 'espace-agent-public',
-        context: 'annuaire-entreprises',
-        recipient: 13002526500013,
-      },
-      useCache,
-    }
+    mapToDomainObject,
+    recipientSiret
   );
-
-  return mapToDomainObject(response);
 };
 
 const mapToDomainObject = (response: IAPIEntrepriseConformiteFiscale) => {

--- a/clients/api-entreprise/conformite/msa.ts
+++ b/clients/api-entreprise/conformite/msa.ts
@@ -1,8 +1,7 @@
-import { HttpUnauthorizedError } from '#clients/exceptions';
 import routes from '#clients/routes';
-import constants from '#models/constants';
+import { IConformite } from '#models/espace-agent/donnees-restreintes-entreprise';
 import { Siret } from '#utils/helpers';
-import { httpGet } from '#utils/network';
+import clientAPIEntreprise from '../client';
 
 export type IAPIEntrepriseConformiteMSA = {
   data: {
@@ -15,31 +14,15 @@ export type IAPIEntrepriseConformiteMSA = {
 /**
  * GET documents from API Entreprise
  */
-export const clientApiEntrepriseConformiteMSA = async (siret: Siret) => {
-  if (!process.env.API_ENTREPRISE_URL || !process.env.API_ENTREPRISE_TOKEN) {
-    throw new HttpUnauthorizedError('Missing API Entreprise credentials');
-  }
-
-  // never cache any API Entreprise request
-  const useCache = false;
-
-  const response = await httpGet<IAPIEntrepriseConformiteMSA>(
+export const clientApiEntrepriseConformiteMSA = async (
+  siret: Siret,
+  recipientSiret?: string
+) => {
+  return await clientAPIEntreprise<IAPIEntrepriseConformiteMSA, IConformite>(
     `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.conformite.msa}${siret}/conformite_cotisations`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.API_ENTREPRISE_TOKEN}`,
-      },
-      timeout: constants.timeout.XXXL,
-      params: {
-        object: 'espace-agent-public',
-        context: 'annuaire-entreprises',
-        recipient: 13002526500013,
-      },
-      useCache,
-    }
+    mapToDomainObject,
+    recipientSiret
   );
-
-  return mapToDomainObject(response);
 };
 
 const mapToDomainObject = (response: IAPIEntrepriseConformiteMSA) => {

--- a/clients/api-entreprise/conformite/vigilance.ts
+++ b/clients/api-entreprise/conformite/vigilance.ts
@@ -1,8 +1,7 @@
-import { HttpUnauthorizedError } from '#clients/exceptions';
 import routes from '#clients/routes';
-import constants from '#models/constants';
+import { IConformite } from '#models/espace-agent/donnees-restreintes-entreprise';
 import { Siren } from '#utils/helpers';
-import { httpGet } from '#utils/network';
+import clientAPIEntreprise from '../client';
 
 export type IAPIEntrepriseConformiteVigilance = {
   data: {
@@ -22,31 +21,18 @@ export type IAPIEntrepriseConformiteVigilance = {
 /**
  * GET documents from API Entreprise
  */
-export const clientApiEntrepriseConformiteVigilance = async (siren: Siren) => {
-  if (!process.env.API_ENTREPRISE_URL || !process.env.API_ENTREPRISE_TOKEN) {
-    throw new HttpUnauthorizedError('Missing API Entreprise credentials');
-  }
-
-  // never cache any API Entreprise request
-  const useCache = false;
-
-  const response = await httpGet<IAPIEntrepriseConformiteVigilance>(
+export const clientApiEntrepriseConformiteVigilance = async (
+  siren: Siren,
+  recipientSiret?: string
+) => {
+  return await clientAPIEntreprise<
+    IAPIEntrepriseConformiteVigilance,
+    IConformite
+  >(
     `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.conformite.vigilance}${siren}/attestation_vigilance`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.API_ENTREPRISE_TOKEN}`,
-      },
-      timeout: constants.timeout.XXXL,
-      params: {
-        object: 'espace-agent-public',
-        context: 'annuaire-entreprises',
-        recipient: 13002526500013,
-      },
-      useCache,
-    }
+    mapToDomainObject,
+    recipientSiret
   );
-
-  return mapToDomainObject(response);
 };
 
 const mapToDomainObject = (response: IAPIEntrepriseConformiteVigilance) => {

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -150,6 +150,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
     tranche_effectif_salarie = null,
     annee_tranche_effectif_salarie = null,
     date_creation,
+    date_fermeture,
     date_mise_a_jour,
     date_mise_a_jour_insee,
     date_mise_a_jour_rne,
@@ -259,6 +260,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
     dateDerniereMiseAJour: date_mise_a_jour || '',
     dateMiseAJourInsee: date_mise_a_jour_insee || '',
     dateMiseAJourInpi: date_mise_a_jour_rne || '',
+    dateFermeture: date_fermeture ?? '',
     conventionsCollectives: etablissements.reduce(
       (idccSiretPair, { siret, liste_idcc }) => {
         (liste_idcc || []).forEach((idcc) => {
@@ -346,6 +348,7 @@ const mapToEtablissement = (
     activite_principale = '',
     date_creation = '',
     date_debut_activite = '',
+    date_fermeture = '',
     tranche_effectif_salarie = '',
     caractere_employeur = '',
     annee_tranche_effectif_salarie = '',
@@ -399,7 +402,8 @@ const mapToEtablissement = (
       libelleFromCodeNAFWithoutNomenclature(activite_principale),
     activitePrincipale: activite_principale,
     dateCreation: parseDateCreationInsee(date_creation),
-    dateDebutActivite: date_debut_activite,
+    dateDebutActivite: date_debut_activite ?? '',
+    dateFermeture: date_fermeture ?? '',
     complements: {
       estEntrepreneurIndividuel,
       idFiness: liste_finess || [],

--- a/clients/recherche-entreprise/interface.ts
+++ b/clients/recherche-entreprise/interface.ts
@@ -14,6 +14,7 @@ export type IResult = {
   siege: ISiege;
   activite_principale: string;
   date_creation: string;
+  date_fermeture: string;
   date_mise_a_jour: string;
   date_mise_a_jour_insee: string;
   date_mise_a_jour_rne: string;
@@ -61,6 +62,7 @@ export type IEtablissementCore = {
   siret: string;
   date_creation: string;
   date_debut_activite: string;
+  date_fermeture: string;
   tranche_effectif_salarie: string;
   caractere_employeur: string;
   annee_tranche_effectif_salarie: string;

--- a/components/unite-legale-section/index.tsx
+++ b/components/unite-legale-section/index.tsx
@@ -87,7 +87,14 @@ const UniteLegaleSection: React.FC<{
         ]
       : []),
     ...(!estActif(uniteLegale)
-      ? [['Date de fermeture', formatDate(uniteLegale.dateDebutActivite)]]
+      ? [
+          [
+            'Date de fermeture',
+            formatDate(
+              uniteLegale.dateDebutActivite || uniteLegale.dateFermeture
+            ),
+          ],
+        ]
       : []),
     ['', <br />],
     [

--- a/models/core/types.ts
+++ b/models/core/types.ts
@@ -96,6 +96,7 @@ export interface IUniteLegale extends IEtablissementsList {
   dateMiseAJourInsee: string;
   dateMiseAJourInpi: string;
   dateDebutActivite: string;
+  dateFermeture: string;
   statutDiffusion: ISTATUTDIFFUSION; // diffusion des données autorisée - uniquement les EI
   etatAdministratif: IETATADMINSTRATIF;
   nomComplet: string;

--- a/models/core/types.ts
+++ b/models/core/types.ts
@@ -134,6 +134,7 @@ export const createDefaultUniteLegale = (siren: Siren): IUniteLegale => {
     activitePrincipale: '',
     libelleActivitePrincipale: '',
     dateCreation: '',
+    dateFermeture: '',
     dateDerniereMiseAJour: '',
     dateMiseAJourInsee: '',
     dateMiseAJourInpi: '',

--- a/models/espace-agent/donnees-restreintes-entreprise.ts
+++ b/models/espace-agent/donnees-restreintes-entreprise.ts
@@ -25,7 +25,8 @@ export type IConformiteUniteLegale = {
 
 export const getDonneesRestreintesEntreprise = async (
   siren: Siren,
-  siret: Siret
+  siret: Siret,
+  recipientSiret?: string
 ): Promise<IConformiteUniteLegale> => {
   const handleApiEntrepriseError = (e: any) => {
     if (e instanceof HttpNotFound) {
@@ -47,11 +48,15 @@ export const getDonneesRestreintesEntreprise = async (
   };
 
   const [fiscale, vigilance, msa] = await Promise.all([
-    clientApiEntrepriseConformiteFiscale(siren).catch(handleApiEntrepriseError),
-    clientApiEntrepriseConformiteVigilance(siren).catch(
+    clientApiEntrepriseConformiteFiscale(siren, recipientSiret).catch(
       handleApiEntrepriseError
     ),
-    clientApiEntrepriseConformiteMSA(siret).catch(handleApiEntrepriseError),
+    clientApiEntrepriseConformiteVigilance(siren, recipientSiret).catch(
+      handleApiEntrepriseError
+    ),
+    clientApiEntrepriseConformiteMSA(siret, recipientSiret).catch(
+      handleApiEntrepriseError
+    ),
   ]);
 
   return {

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -15,8 +15,8 @@ const ServerError: NextPageWithLayout = () => {
 
 ServerError.getInitialProps = (...args) => {
   // log as JSON in order to be parse by Kibana
-  console.error(args[0]);
   try {
+    console.error(args[0]);
     const { res, err } = args[0];
     logFatalErrorInSentry(
       new Exception({
@@ -27,7 +27,16 @@ ServerError.getInitialProps = (...args) => {
         },
       })
     );
-  } catch (e) {}
+  } catch (e) {
+    console.error('Failed to parse NextPageRequest, returning 500');
+    logFatalErrorInSentry(
+      new Exception({
+        name: 'ServerErrorPageDisplayed',
+        cause: e,
+        context: {},
+      })
+    );
+  }
   return { statusCode: 500 };
 };
 

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -14,8 +14,8 @@ const ServerError: NextPageWithLayout = () => {
 };
 
 ServerError.getInitialProps = (...args) => {
-  // eslint-disable-next-line no-console
-  console.log('ERROR', args);
+  // log as JSON in order to be parse by Kibana
+  console.error(args[0]);
   try {
     const { res, err } = args[0];
     logFatalErrorInSentry(

--- a/pages/api/auth/agent-connect/callback.ts
+++ b/pages/api/auth/agent-connect/callback.ts
@@ -42,8 +42,9 @@ export default withSession(async function callbackRoute(req, res) {
 
     await setAgentSession(
       userInfo.email,
-      userInfo.family_name || '',
-      userInfo.given_name || '',
+      userInfo.family_name ?? '',
+      userInfo.given_name ?? '',
+      userInfo.siret ?? '',
       userPrivilege,
       session
     );

--- a/pages/api/data-fetching/espace-agent/conformite/[slug].tsx
+++ b/pages/api/data-fetching/espace-agent/conformite/[slug].tsx
@@ -17,12 +17,15 @@ export default withSession(async function conformite(req, res) {
       throw new HttpForbiddenError('Unauthorized account');
     }
 
+    const agentSiret = session?.user?.siret;
+
     const siret = verifySiret(slug as string);
     const siren = extractSirenFromSiret(siret);
 
     const donneesRestreintes = await getDonneesRestreintesEntreprise(
       siren,
-      siret
+      siret,
+      agentSiret
     );
     res.status(200).json(donneesRestreintes);
   } catch (e: any) {

--- a/pages/api/data-fetching/espace-agent/documents/download/[slug].tsx
+++ b/pages/api/data-fetching/espace-agent/documents/download/[slug].tsx
@@ -50,3 +50,11 @@ export default withSession(async function download(req, res) {
     res.status(e.status || 500).json({ message });
   }
 });
+
+// Actes can often be bigger than 4MB
+// https://nextjs.org/docs/messages/api-routes-response-size-limit#possible-ways-to-fix-it
+export const config = {
+  api: {
+    responseLimit: false,
+  },
+};

--- a/utils/session/index.ts
+++ b/utils/session/index.ts
@@ -10,6 +10,7 @@ export type ISession = {
     firstName?: string;
     fullName?: string;
     privilege?: ISessionPrivilege;
+    siret?: string;
   };
 
   // agent connect
@@ -47,6 +48,7 @@ export const setAgentSession = async (
   email: string,
   familyName: string,
   firstName: string,
+  siret: string,
   privilege: ISessionPrivilege,
   session: IronSession<ISession>
 ) => {
@@ -56,6 +58,7 @@ export const setAgentSession = async (
     familyName,
     fullName: familyName ? `${firstName} ${familyName}` : undefined,
     privilege,
+    siret,
   };
   await session.save();
 };


### PR DESCRIPTION
Not best practise, but this is a mix of fixes. Each commit can be read indendantly

- change the way we log server error in order to be able to read them in Kibana
- handle >4MB actes & bilans
  - we should probably move to a dedicted service that would download files and handles queues
  - @MKCG 
- date fermeture
- recipient siret to API Entreprise