### PR TITLE
chore: the SSH command exit status is always forwarded to the executor

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -27,7 +27,7 @@ jobs:
           SSH_HOST: ${{ secrets.SSH_HOST_STAGING_V2 }}
 
       - name: Deploy website to staging
-        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-site https://github.com/etalab/annuaire-entreprises-site.git website --version main --versions_to_keep=5 | tee --append /var/log/deploy_annuaire-entreprises-site'
+        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-site https://github.com/etalab/annuaire-entreprises-site.git website --version main --versions_to_keep=5 1> >(tee --append /var/log/deploy_annuaire-entreprises-site)'
         env:
           SSH_HOST: ${{ secrets.SSH_HOST_STAGING_V2 }}
 


### PR DESCRIPTION
Up until now, when an error occured during the deployment, it was not reported in the Github action. This was due to the presence of the pipe that was sending both the stdout & the stderr to the tee command.


---
### Before

expected : 
```
/usr/bin/docker
success
```

actual : 
```
/usr/bin/docker
success
```

```sh
ssh annuaire-entreprises-staging-www-1 'which docker | tee --append /tmp/debug_err' && echo 'success' || echo 'error' 
```

---
### After

expected : 
```
/usr/bin/docker
success
```

actual : 
```
/usr/bin/docker
success
```

```sh
ssh annuaire-entreprises-staging-www-1 'which docker 1> >(tee --append /tmp/debug_err)' && echo 'success' || echo 'error'
```


---
### Before

expected : "error"
actual : "success"

```sh
ssh annuaire-entreprises-staging-www-1 'which foobar | tee --append /tmp/debug_err' && echo 'success' || echo 'error' 
```

---
### After

expected : "error"
actual : "error"

```sh
ssh annuaire-entreprises-staging-www-1 'which foobar 1> >(tee --append /tmp/debug_err)' && echo 'success' || echo 'error'
```