### PR TITLE
[fix] wrong link in "partager"

### DIFF
--- a/pages/partager/index.tsx
+++ b/pages/partager/index.tsx
@@ -221,7 +221,7 @@ const Partager: NextPageWithLayout = () => {
           <p>
             Toutes les données utilisées sur l’Annuaire des Entreprises sont
             librement accessibles par API. Consultez la page{' '}
-            <a href="/administration">statut des API</a> pour en savoir plus.
+            <a href="/donnees/api">statut des API</a> pour en savoir plus.
           </p>
         </div>
       </TextWrapper>


### PR DESCRIPTION
- Correction d'un bug.
- Zones impactées : `pages/partager/index.tsx`.
- Détails :
  - Lien vers 'status des api' renvoie vers "/administration" au lieu de "/donnees/api" sur la page partagée

- Notes :
 - Le lien "/donnes" renvoie une erreur 404
 - Je cherche une alternance à Montpellier/à distance si vous êtes intéressé...
