### PR TITLE
fix: prevent safari from interpreting phone

### DIFF
--- a/components/meta/meta-server.tsx
+++ b/components/meta/meta-server.tsx
@@ -13,6 +13,8 @@ export function meta(obj: Metadata): Metadata {
   obj.openGraph.images ??= OPENGRAPH_IMAGES;
   obj.openGraph.siteName = SITE_NAME;
 
+  obj.formatDetection = { telephone: false };
+
   if (typeof obj.alternates?.canonical === 'string') {
     obj.openGraph.url ??= obj.alternates.canonical;
   }


### PR DESCRIPTION
Cf : https://github.com/vercel/next.js/issues/43914
references #947 