### PR TITLE
fix: missing GET in backend logs

### DIFF
--- a/utils/network/backend/log-interceptor.ts
+++ b/utils/network/backend/log-interceptor.ts
@@ -30,7 +30,7 @@ export const logInterceptor = (response: AxiosResponse<any, any>) => {
       //@ts-ignore
       response?.cached,
       startTime ? endTime - startTime : undefined,
-      response?.request?.method
+      (response?.config?.method || '').toUpperCase()
     )
   );
   return response;


### PR DESCRIPTION
Method was absent from cached response and therefore absent from backend logs. 